### PR TITLE
Refine orgunits

### DIFF
--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -19,25 +19,9 @@ describe("Campaign configurator - Create", () => {
         cy.contains("Next").click();
         cy.contains("Select at least one organisation unit");
 
-        const onlyLevel6Msg = "Only organisation units of level 6 can be selected";
-
-        selectOrgUnit("MSF");
-        cy.contains(onlyLevel6Msg);
-
-        selectOrgUnit("OCBA");
-        cy.contains(onlyLevel6Msg);
         expandOrgUnit("OCBA");
-
-        selectOrgUnit("ANGOLA");
-        cy.contains(onlyLevel6Msg);
         expandOrgUnit("ANGOLA");
-
-        selectOrgUnit("HUAMBO");
-        cy.contains(onlyLevel6Msg);
         expandOrgUnit("HUAMBO");
-
-        selectOrgUnit("Hospital central de Huambo");
-        cy.contains(onlyLevel6Msg);
         expandOrgUnit("Hospital central de Huambo");
 
         selectOrgUnit("Emergency Room");

--- a/src/components/objects-table/ObjectsTable.js
+++ b/src/components/objects-table/ObjectsTable.js
@@ -133,7 +133,7 @@ class ObjectsTable extends React.Component {
     };
 
     _onColumnSort = sorting => {
-        this.setState({ sorting }, this.getDataSets);
+        this.setState({ sorting, isLoading: true }, this.getDataSets);
     };
 
     _toggleShowOnlyUserCampaigns = ev => {

--- a/src/components/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/components/org-units-selector/OrgUnitsSelector.jsx
@@ -56,6 +56,13 @@ const styles = {
         padding: "1px 6px 1px 3px",
         fontStyle: "italic",
     },
+    selectByLevel: {
+        marginBottom: -24,
+        marginTop: -16,
+    },
+    selectAll: {
+        float: "right",
+    }
 };
 styles.cardWide = Object.assign({}, styles.card, {
     width: 1052,
@@ -132,15 +139,29 @@ export default class OrgUnitsSelector extends React.Component {
         }));
     };
 
-    render() {
-        const changeRoot = currentRoot => {
-            this.setState({ currentRoot });
-        };
+    renderOrgUnitSelectTitle = () => {
+        const { currentRoot } = this.state;
 
-        const state = this.state;
-        if (!state.levels) {
-            return null;
-        }
+        return currentRoot ? (
+            <div>
+                {i18n.t("For organisation units within")}
+                <span style={styles.ouLabel}>{currentRoot.displayName}</span>:{" "}
+            </div>
+        ) : (
+            <div>{i18n.t("For all organisation units")}:</div>
+        );
+    };
+
+    changeRoot = currentRoot => {
+        this.setState({ currentRoot });
+    };
+
+    render() {
+        const { levels, currentRoot, rootWithMembers, groups } = this.state;
+        const { selected } = this.props;
+        const { renderOrgUnitSelectTitle: OrgUnitSelectTitle } = this;
+
+        if (!levels) return null;
 
         return (
             <div>
@@ -148,52 +169,42 @@ export default class OrgUnitsSelector extends React.Component {
                     <CardText style={styles.cardText}>
                         <div style={styles.left}>
                             <OrgUnitTree
-                                root={this.state.rootWithMembers}
-                                selected={this.props.selected}
-                                currentRoot={this.state.currentRoot}
-                                initiallyExpanded={[`/${this.state.rootWithMembers.id}`]}
+                                root={rootWithMembers}
+                                selected={selected}
+                                currentRoot={currentRoot}
+                                initiallyExpanded={[`/${rootWithMembers.id}`]}
                                 onSelectClick={this.handleOrgUnitClick}
-                                onChangeCurrentRoot={changeRoot}
+                                onChangeCurrentRoot={this.changeRoot}
                                 onChildrenLoaded={this.handleChildrenLoaded}
                             />
                         </div>
 
                         <div style={styles.right}>
                             <div>
-                                {this.state.currentRoot ? (
-                                    <div>
-                                        {i18n.t("For organisation units within")}
-                                        <span style={styles.ouLabel}>
-                                            {this.state.currentRoot.displayName}
-                                        </span>
-                                        :{" "}
-                                    </div>
-                                ) : (
-                                    <div>{i18n.t("For all organisation units")}:</div>
-                                )}
+                                <OrgUnitSelectTitle />
 
-                                <div style={{ marginBottom: -24, marginTop: -16 }}>
+                                <div style={styles.selectByLevel}>
                                     <OrgUnitSelectByLevel
-                                        levels={this.state.levels}
-                                        selected={this.props.selected}
-                                        currentRoot={this.state.currentRoot}
+                                        levels={levels}
+                                        selected={selected}
+                                        currentRoot={currentRoot}
                                         onUpdateSelection={this.handleSelectionUpdate}
                                     />
                                 </div>
 
                                 <div>
                                     <OrgUnitSelectByGroup
-                                        groups={this.state.groups}
-                                        selected={this.props.selected}
-                                        currentRoot={this.state.currentRoot}
+                                        groups={groups}
+                                        selected={selected}
+                                        currentRoot={currentRoot}
                                         onUpdateSelection={this.handleSelectionUpdate}
                                     />
                                 </div>
 
-                                <div style={{ float: "right" }}>
+                                <div style={styles.selectAll}>
                                     <OrgUnitSelectAll
-                                        selected={this.props.selected}
-                                        currentRoot={this.state.currentRoot}
+                                        selected={selected}
+                                        currentRoot={currentRoot}
                                         onUpdateSelection={this.handleSelectionUpdate}
                                     />
                                 </div>

--- a/src/components/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/components/org-units-selector/OrgUnitsSelector.jsx
@@ -62,7 +62,7 @@ const styles = {
     },
     selectAll: {
         float: "right",
-    }
+    },
 };
 styles.cardWide = Object.assign({}, styles.card, {
     width: 1052,
@@ -73,6 +73,7 @@ export default class OrgUnitsSelector extends React.Component {
         d2: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
         selected: PropTypes.arrayOf(PropTypes.string).isRequired,
+        levels: PropTypes.arrayOf(PropTypes.number),
     };
 
     static childContextTypes = {
@@ -91,6 +92,14 @@ export default class OrgUnitsSelector extends React.Component {
                 paging: false,
                 fields: "id,level,displayName",
                 order: "level:asc",
+                // bug in old versions of dhis2, cannot use filter=level:in:[1,2] -> HTTP 500
+                // filter: props.levels ? `level:in:[${props.levels.join(',')}]` : undefined,
+                ...(props.levels
+                    ? {
+                          filter: props.levels.map(level => `level:eq:${level}`),
+                          rootJunction: "OR",
+                      }
+                    : {}),
             }),
             props.d2.models.organisationUnitGroups.list({
                 paging: false,

--- a/src/components/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/components/org-units-selector/OrgUnitsSelector.jsx
@@ -176,8 +176,7 @@ export default class OrgUnitsSelector extends React.Component {
                       fields: "id,displayName,path",
                       filter: `displayName:ilike:${value}`,
                   })
-                  .then(collection => collection.toArray())
-        );
+                  .then(collection => collection.toArray()));
 
         this.setState({ roots });
     };
@@ -209,7 +208,10 @@ export default class OrgUnitsSelector extends React.Component {
                                         initiallyExpanded={initiallyExpanded}
                                         onSelectClick={this.handleOrgUnitClick.bind(this, root)}
                                         onChangeCurrentRoot={this.changeRoot}
-                                        onChildrenLoaded={this.handleChildrenLoaded.bind(this, root)}
+                                        onChildrenLoaded={this.handleChildrenLoaded.bind(
+                                            this,
+                                            root
+                                        )}
                                     />
                                 </div>
                             ))}
@@ -283,9 +285,11 @@ function mergeChildren(root, children) {
 }
 
 function getDefaultRoots(d2) {
-    return d2.models.organisationUnits.list({
-        paging: false,
-        level: 1,
-        fields: "id,displayName,path,children::isNotEmpty",
-    }).then(collection => collection.toArray());
+    return d2.models.organisationUnits
+        .list({
+            paging: false,
+            level: 1,
+            fields: "id,displayName,path,children::isNotEmpty",
+        })
+        .then(collection => collection.toArray());
 }

--- a/src/components/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/components/org-units-selector/OrgUnitsSelector.jsx
@@ -189,6 +189,7 @@ export default class OrgUnitsSelector extends React.Component {
         const { selected } = this.props;
         const { renderOrgUnitSelectTitle: OrgUnitSelectTitle } = this;
         const initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path);
+        const getClass = root => `ou-root-${root.path.split("/").length - 1}`;
 
         return (
             <div>
@@ -199,17 +200,18 @@ export default class OrgUnitsSelector extends React.Component {
                         </div>
 
                         <div style={styles.left}>
-                            {roots.map((root, index) => (
-                                <OrgUnitTree
-                                    key={root.path + index}
-                                    root={root}
-                                    selected={selected}
-                                    currentRoot={currentRoot}
-                                    initiallyExpanded={initiallyExpanded}
-                                    onSelectClick={this.handleOrgUnitClick.bind(this, root)}
-                                    onChangeCurrentRoot={this.changeRoot}
-                                    onChildrenLoaded={this.handleChildrenLoaded.bind(this, root)}
-                                />
+                            {roots.map(root => (
+                                <div key={root.path} className={`ou-root ${getClass(root)}`}>
+                                    <OrgUnitTree
+                                        root={root}
+                                        selected={selected}
+                                        currentRoot={currentRoot}
+                                        initiallyExpanded={initiallyExpanded}
+                                        onSelectClick={this.handleOrgUnitClick.bind(this, root)}
+                                        onChangeCurrentRoot={this.changeRoot}
+                                        onChildrenLoaded={this.handleChildrenLoaded.bind(this, root)}
+                                    />
+                                </div>
                             ))}
                         </div>
 
@@ -264,7 +266,7 @@ function mergeChildren(root, children) {
             if (nextRoot) {
                 assignChildren(nextRoot, targetPath, children);
             } else {
-                throw new Error("Cannot find root children");
+                console.error("Cannot find root children", root, targetPath);
             }
         }
         return root;

--- a/src/components/search-box/SearchBox.component.js
+++ b/src/components/search-box/SearchBox.component.js
@@ -10,31 +10,32 @@ class SearchBox extends React.Component {
         debounce: PropTypes.number,
     };
 
+    static defaultProps = {
+        debounce: 400,
+    };
+
     constructor(props) {
         super(props);
         this.state = { value: "" };
-        this.onChangeDebounced = debounce(500, props.onChange);
+        this.onChangeDebounced = debounce(props.debounce, props.onChange);
     }
 
     render() {
         return (
-            <div className="search-list-items">
-                <TextField
-                    className="list-search-field"
-                    value={this.state.value}
-                    fullWidth
-                    type="search"
-                    onChange={this._onKeyUp}
-                    hintText={`${i18n.t("Search by name")}`}
-                    data-test="search"
-                />
-            </div>
+            <TextField
+                value={this.state.value}
+                fullWidth
+                type="search"
+                onChange={this.onKeyUp}
+                hintText={`${i18n.t("Search by name")}`}
+                data-test="search"
+            />
         );
     }
 
-    _onKeyUp = event => {
+    onKeyUp = event => {
         const { value } = event.target;
-        this.onChangeDebounced(value);
+        this.onChangeDebounced(value.trim());
         this.setState({ value });
     };
 }

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.css
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.css
@@ -2,26 +2,26 @@
     display: none;
 }
 
-.ou-root-1 .tree-view .tree-view .tree-view .tree-view .tree-view .children svg {
+.ou-root-1 .orgunit .orgunit .orgunit .orgunit .orgunit .children svg {
     display: inline;
 }
 
-.ou-root-2 .tree-view .tree-view .tree-view .tree-view .children svg {
+.ou-root-2 .orgunit .orgunit .orgunit .orgunit .children svg {
     display: inline;
 }
 
-.ou-root-3 .tree-view .tree-view .tree-view .children svg {
+.ou-root-3 .orgunit .orgunit .orgunit .children svg {
     display: inline;
 }
 
-.ou-root-4 .tree-view .tree-view .children svg {
+.ou-root-4 .orgunit .orgunit .children svg {
     display: inline;
 }
 
-.ou-root-5 .tree-view .children svg {
+.ou-root-5 .orgunit .children svg {
     display: inline;
 }
 
-.ou-root-6 .tree-view svg {
+.ou-root-6 .orgunit svg {
     display: inline;
 }

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.css
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.css
@@ -1,0 +1,27 @@
+.ou-root svg {
+    display: none;
+}
+
+.ou-root-1 .tree-view .tree-view .tree-view .tree-view .tree-view .children svg {
+    display: inline;
+}
+
+.ou-root-2 .tree-view .tree-view .tree-view .tree-view .children svg {
+    display: inline;
+}
+
+.ou-root-3 .tree-view .tree-view .tree-view .children svg {
+    display: inline;
+}
+
+.ou-root-4 .tree-view .tree-view .children svg {
+    display: inline;
+}
+
+.ou-root-5 .tree-view .children svg {
+    display: inline;
+}
+
+.ou-root-6 .tree-view svg {
+    display: inline;
+}

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
@@ -2,8 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import OrgUnitsSelector from "../../org-units-selector/OrgUnitsSelector";
 import _ from "lodash";
-import { withFeedback, levels } from "../../feedback";
-import { getValidationMessages } from "../../../utils/validations";
+import { withFeedback } from "../../feedback";
 
 class OrganisationUnitsStep extends React.Component {
     static propTypes = {
@@ -16,17 +15,13 @@ class OrganisationUnitsStep extends React.Component {
     setOrgUnits = orgUnitsPaths => {
         const orgUnits = orgUnitsPaths.map(path => ({
             id: _.last(path.split("/")),
+            level: path.split("/").length - 1,
             path,
         }));
-
-        const newCampaign = this.props.campaign.setOrganisationUnits(orgUnits);
-        const messages = getValidationMessages(newCampaign, ["organisationUnits"]);
-
-        if (!_(messages).isEmpty()) {
-            this.props.feedback(levels.ERROR, messages.join("\n"));
-        } else {
-            this.props.onChange(newCampaign);
-        }
+        const orgUnitsForAcceptedLevels =
+            orgUnits.filter(ou => this.props.campaign.selectableLevels.includes(ou.level));
+        const newCampaign = this.props.campaign.setOrganisationUnits(orgUnitsForAcceptedLevels);
+        this.props.onChange(newCampaign);
     };
 
     render() {
@@ -37,6 +32,7 @@ class OrganisationUnitsStep extends React.Component {
                 d2={d2}
                 onChange={this.setOrgUnits}
                 selected={campaign.organisationUnits.map(ou => ou.path)}
+                levels={campaign.selectableLevels}
             />
         );
     }

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
@@ -3,6 +3,13 @@ import PropTypes from "prop-types";
 import OrgUnitsSelector from "../../org-units-selector/OrgUnitsSelector";
 import _ from "lodash";
 import { withFeedback } from "../../feedback";
+import './OrganisationUnitsStep.css';
+
+/*
+    HACK: Use css to hide all selector boxes in org tree except for those of level 6.
+    This way, we don't have to fork the @dhis2/d2-ui OrgUnitTree component. This component
+    does have a prop hideCheckboxes, but it's just a bool (ideally, should get a predicate)
+*/
 
 class OrganisationUnitsStep extends React.Component {
     static propTypes = {

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import OrgUnitsSelector from "../../org-units-selector/OrgUnitsSelector";
 import _ from "lodash";
 import { withFeedback } from "../../feedback";
-import './OrganisationUnitsStep.css';
+import "./OrganisationUnitsStep.css";
 
 /*
     HACK: Use css to hide all selector boxes in org tree except for those of level 6.

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
@@ -18,8 +18,9 @@ class OrganisationUnitsStep extends React.Component {
             level: path.split("/").length - 1,
             path,
         }));
-        const orgUnitsForAcceptedLevels =
-            orgUnits.filter(ou => this.props.campaign.selectableLevels.includes(ou.level));
+        const orgUnitsForAcceptedLevels = orgUnits.filter(ou =>
+            this.props.campaign.selectableLevels.includes(ou.level)
+        );
         const newCampaign = this.props.campaign.setOrganisationUnits(orgUnitsForAcceptedLevels);
         this.props.onChange(newCampaign);
     };

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -23,6 +23,7 @@ export interface Data {
 }
 
 export default class Campaign {
+    // Update OrganisationUnitStep.css accordingly if you change this value.
     public selectableLevels: number[] = [6];
 
     constructor(private db: DbD2, private data: Data) {

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -23,7 +23,7 @@ export interface Data {
 }
 
 export default class Campaign {
-    selectableLevels: number[] = [6];
+    public selectableLevels: number[] = [6];
 
     constructor(private db: DbD2, private data: Data) {
     }
@@ -67,7 +67,7 @@ export default class Campaign {
                     namespace: {levels: this.selectableLevels.join("/")},
                 } : null,
                 _(organisationUnits).isEmpty() ? {
-                    key: "no_organisation_units_selected"
+                    key: "no_organisation_units_selected",
                 } : null,
             ]),
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #25 

### :memo: Implementation

- The orgunit selector example in @dhis2/d2-ui had no search bar nor support for multiple roots, some cade has been added
- As we discussed, I've used to hide non-level=6 orgunits. It's a hack, but works fine and and can be changed at any moment.

### :art: Screenshots

![screenshot from 2019-02-12 11-59-51](https://user-images.githubusercontent.com/24643/52630969-eeb44900-2ebd-11e9-9103-4d2fdac566cc.png)