### PR TITLE
Public datasets

### DIFF
--- a/src/components/objects-table/ObjectsTable.js
+++ b/src/components/objects-table/ObjectsTable.js
@@ -278,7 +278,8 @@ class ObjectsTable extends React.Component {
                     ) : null}
                 </div>
 
-                {canCreate(d2) && <ListActionBar onClick={this.newDataset} />}
+                {canCreate(d2, d2.models.dataSet, "public") &&
+                    <ListActionBar onClick={this.newDataset} />}
             </div>
         );
     }

--- a/src/components/objects-table/actions.js
+++ b/src/components/objects-table/actions.js
@@ -46,19 +46,19 @@ export function get(onClick) {
             name: "edit",
             text: i18n.t("Edit"),
             multiple: false,
-            isActive: (d2, dataset) => canUpdate(d2, [dataset]),
+            isActive: (d2, dataSet) => canUpdate(d2, d2.models.dataSet, [dataSet]),
         },
         {
             name: "share",
             text: i18n.t("Share"),
             multiple: true,
-            isActive: canManage,
+            isActive: (d2, dataSets) => canManage(d2, d2.models.dataSet, dataSets),
         },
         {
             name: "delete",
             text: i18n.t("Delete"),
             multiple: true,
-            isActive: canDelete,
+            isActive: (d2, dataSets) => canDelete(d2, d2.models.dataSet, dataSets),
         },
         {
             name: "dataEntry",

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -189,7 +189,7 @@ export default class Campaign {
             const dataSet: DataSet = {
                 id: dataSetId,
                 name: this.name,
-                publicAccess: "--------",
+                publicAccess: "r-r-----", // Metadata can view-only, Data can view-only
                 periodType: "Daily",
                 categoryCombo: {id: categoryComboTeams.id},
                 dataElementDecoration: true,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -11,30 +11,30 @@ function hasRequiredAuthorities(d2) {
     return requiredAuthorities.every(authority => d2.currentUser.authorities.has(authority));
 }
 
-export function canManage(d2, datasets) {
-    return datasets.every(dataset => dataset.access.manage);
+export function canManage(d2, model, objs) {
+    return objs.every(obj => obj.access && obj.access.manage);
 }
 
-export function canCreate(d2) {
-    return d2.currentUser.canCreatePrivate(d2.models.dataSets) && hasRequiredAuthorities(d2);
+export function canCreate(d2, model, type) {
+    const method = type === "private" ? "canCreatePrivate" : "canCreatePublic";
+    return d2.currentUser[method](model) && hasRequiredAuthorities(d2);
 }
 
-export function canDelete(d2, datasets) {
+export function canDelete(d2, model, objs) {
+    if (objs.length === 0) return true;
     return (
-        d2.currentUser.canDelete(d2.models.dataSets) &&
-        _(datasets).every(dataset => dataset.access.delete) &&
+        d2.currentUser.canDelete(model) &&
+        _(objs).every(obj => obj.access && obj.access.delete) &&
         hasRequiredAuthorities(d2)
     );
 }
 
-export function canUpdate(d2, datasets) {
-    const publicDatasetsSelected = _(datasets).some(dataset => dataset.publicAccess.match(/^r/));
-    const privateDatasetsSelected = _(datasets).some(dataset => dataset.publicAccess.match(/^-/));
-    const datasetsUpdatable = _(datasets).every(dataset => dataset.access.update);
-    const privateCondition =
-        !privateDatasetsSelected || d2.currentUser.canCreatePrivate(d2.models.dataSets);
-    const publicCondition =
-        !publicDatasetsSelected || d2.currentUser.canCreatePublic(d2.models.dataSets);
-
-    return hasRequiredAuthorities(d2) && privateCondition && publicCondition && datasetsUpdatable;
+export function canUpdate(d2, model, objs) {
+    if (objs.length === 0) return true;
+    const anyPublic = _(objs).some(obj => obj.publicAccess.match(/^r/));
+    const anyPrivate = _(objs).some(obj => obj.publicAccess.match(/^-/));
+    const allUpdatable = _(objs).every(obj => obj.access.update);
+    const privateCondition = !anyPrivate || d2.currentUser.canCreatePrivate(model);
+    const publicCondition = !anyPublic || d2.currentUser.canCreatePublic(model);
+    return hasRequiredAuthorities(d2) && privateCondition && publicCondition && allUpdatable;
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #40 

### :memo: Implementation

- From 2.29, datasets have also data sharing settings. "r-r-" means read-only metadata + read-only data.
- Do some abstracting work on utils/auth.js
