### PR TITLE
Set default start/end dates on campaign creation

### DIFF
--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -14,7 +14,7 @@ describe("Campaign configurator - List page", () => {
 
         cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
             "have.text",
-            "Cholera Outbreak - Daily "
+            "CampTest"
         );
     });
 
@@ -48,7 +48,7 @@ describe("Campaign configurator - List page", () => {
 
         cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
             "have.text",
-            "Cholera Outbreak - Daily "
+            "CampTest"
         );
 
         cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").should(

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -52,14 +52,9 @@ export default class Campaign {
                 namespace: {field: "name"}
             } : null,
 
-            startDate: startDate && !endDate ? {
+            startDate: !startDate && endDate ? {
                 key: "cannot_be_blank_if_other_set",
                 namespace: {field: "startDate", other: "endDate"},
-            } : null,
-
-            endDate: endDate && !startDate ? {
-                key: "cannot_be_blank_if_other_set",
-                namespace: {field: "endDate", other: "startDate"},
             } : null,
 
             organisationUnits: _.compact([

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -175,12 +175,11 @@ export default class Campaign {
                     //greyedFields: [],
                 }
             })
-            const startDate = this.startDate || moment().toDate();
-            const endDate = this.endDate || moment().endOf("year").toDate();
+            const endDate = (!this.endDate && this.startDate) ? moment().endOf("year").toDate() : this.endDate;
 
-            const dataInputPeriods = getDaysRange(startDate, endDate).map(date => ({
-                openingDate: startDate.toISOString(),
-                closingDate: endDate.toISOString(),
+            const dataInputPeriods = getDaysRange(this.startDate, endDate).map(date => ({
+                openingDate: this.startDate ? this.startDate.toISOString() : undefined,
+                closingDate: endDate ? endDate.toISOString() : undefined,
                 period: {id: date.format("YYYYMMDD")}
             }));
 

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -1,13 +1,13 @@
-import { MetadataResponse, Section } from './db.types';
 ///<reference path="../types/d2.d.ts" />
-
-import { Dictionary } from 'lodash';
-import { CategoryCombo, DataSet, Response } from './db.types';
-import _ from '../utils/lodash';
+import moment from 'moment';
 import { generateUid } from "d2/uid";
+
+import { MetadataResponse, Section, CategoryCombo, DataSet, Response } from './db.types';
 import { PaginatedObjects, OrganisationUnitPathOnly, CategoryOption } from "./db.types";
-import DbD2 from './db-d2';
+import _ from '../utils/lodash';
 import { getDaysRange } from '../utils/date';
+import DbD2 from './db-d2';
+
 
 const metadataConfig = {
     categoryCodeForAntigens: "RVC_ANTIGENS",
@@ -180,10 +180,12 @@ export default class Campaign {
                     //greyedFields: [],
                 }
             })
+            const startDate = this.startDate || moment().toDate();
+            const endDate = this.endDate || moment().endOf("year").toDate();
 
-            const dataInputPeriods = getDaysRange(this.startDate, this.endDate).map(date => ({
-                openingDate: this.startDate ? this.startDate.toISOString() : undefined,
-                closingDate: this.endDate ? this.endDate.toISOString() : undefined,
+            const dataInputPeriods = getDaysRange(startDate, endDate).map(date => ({
+                openingDate: startDate.toISOString(),
+                closingDate: endDate.toISOString(),
                 period: {id: date.format("YYYYMMDD")}
             }));
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #39 

### :memo: Implementation: Since setting the endDate by itself doesn't affect anything, the startDate is set to Today if left blank as well.