### PR TITLE
Goto dashboard contextual 

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-11T09:50:22.246Z\n"
-"PO-Revision-Date: 2019-03-11T09:50:22.246Z\n"
+"POT-Creation-Date: 2019-03-11T11:33:36.984Z\n"
+"PO-Revision-Date: 2019-03-11T11:33:36.984Z\n"
 
 msgid "Vaccination"
 msgstr ""
@@ -72,6 +72,9 @@ msgid "Go to Dashboard"
 msgstr ""
 
 msgid "Download data"
+msgstr ""
+
+msgid "Cannot find dashboard associated to the campaign"
 msgstr ""
 
 msgid "Only my campaigns"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-03-11T09:50:22.246Z\n"
+"POT-Creation-Date: 2019-03-11T11:33:36.984Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -73,6 +73,9 @@ msgstr "Ir a tablero"
 
 msgid "Download data"
 msgstr "Descargar datos"
+
+msgid "Cannot find dashboard associated to the campaign"
+msgstr "No hay ningún tablero asociado a la campaña"
 
 msgid "Only my campaigns"
 msgstr "Solo mis campañas"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-03-11T09:50:22.246Z\n"
+"POT-Creation-Date: 2019-03-11T11:33:36.984Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -72,6 +72,9 @@ msgid "Go to Dashboard"
 msgstr ""
 
 msgid "Download data"
+msgstr ""
+
+msgid "Cannot find dashboard associated to the campaign"
 msgstr ""
 
 msgid "Only my campaigns"

--- a/src/components/app/LandingPage.js
+++ b/src/components/app/LandingPage.js
@@ -6,7 +6,8 @@ import FontIcon from "material-ui/FontIcon";
 import GridList from "@material-ui/core/GridList";
 import GridListTile from "@material-ui/core/GridListTile";
 import { withStyles } from "@material-ui/core/styles";
-import { Link } from "react-router-dom";
+import { withRouter } from "react-router";
+import { goToDhis2Url } from "../../utils/routes";
 
 const lightGray = "#7a7a7a";
 const styles = _theme => ({
@@ -52,7 +53,23 @@ class LandingPage extends React.Component {
     };
 
     onClick = key => {
-        console.log("TODO", "clicked", key);
+        const { history } = this.props;
+        switch (key) {
+            case "campaign-configuration":
+                history.push("/" + key);
+                break;
+            case "data-entry":
+                goToDhis2Url("/dhis-web-dataentry/index.action");
+                break;
+            case "dashboard":
+                goToDhis2Url("/dhis-web-dashboard/index.html");
+                break;
+            case "maintenance":
+                goToDhis2Url("/dhis-web-maintenance/index.html");
+                break;
+            default:
+                throw new Error(`Unsupported page key: ${key}`);
+        }
     };
 
     render() {
@@ -68,8 +85,6 @@ class LandingPage extends React.Component {
                 key={key}
                 data-test={`page-${key}`}
                 onClick={this.onClick.bind(this, key)}
-                component={Link}
-                to={`/${key}`}
                 className={classes.gridTile}
             >
                 <div className={classes.tileContainer}>
@@ -91,4 +106,4 @@ class LandingPage extends React.Component {
     }
 }
 
-export default withStyles(styles)(LandingPage);
+export default withRouter(withStyles(styles)(LandingPage));

--- a/src/components/app/LandingPage.js
+++ b/src/components/app/LandingPage.js
@@ -27,6 +27,7 @@ const styles = _theme => ({
         "&:hover": {
             backgroundColor: "#f9f9f9",
         },
+        cursor: 'pointer'
     },
     tileContainer: {
         display: "flex",

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Switch, Route } from "react-router-dom";
+
 import CampaignConfigurator from "../campaign-configurator/CampaignConfigurator";
 import LandingPage from "./LandingPage";
 import CampaignWizard from "../campaign-wizard/CampaignWizard";
@@ -26,7 +27,6 @@ class Root extends React.Component {
 
     render() {
         const { d2 } = this.props;
-        const { REACT_APP_DHIS2_BASE_URL } = process.env;
         if (!this.state.config) return null;
 
         return (
@@ -43,27 +43,6 @@ class Root extends React.Component {
                     render={props => (
                         <CampaignConfigurator d2={d2} config={this.state.config} {...props} />
                     )}
-                />
-                <Route
-                    path="/data-entry"
-                    component={() => {
-                        window.location = `${REACT_APP_DHIS2_BASE_URL}/dhis-web-dataentry/index.action`;
-                        return null;
-                    }}
-                />
-                <Route
-                    path="/dashboard"
-                    component={() => {
-                        window.location = `${REACT_APP_DHIS2_BASE_URL}/dhis-web-dashboard/index.html`;
-                        return null;
-                    }}
-                />
-                <Route
-                    path="/maintenance"
-                    component={() => {
-                        window.location = `${REACT_APP_DHIS2_BASE_URL}/dhis-web-maintenance/index.html`;
-                        return null;
-                    }}
                 />
                 <Route render={() => <LandingPage d2={d2} />} />
             </Switch>

--- a/src/components/campaign-configurator/CampaignConfigurator.jsx
+++ b/src/components/campaign-configurator/CampaignConfigurator.jsx
@@ -1,16 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
-import { ObjectsTable } from "d2-ui-components";
+import { ObjectsTable, withSnackbar } from "d2-ui-components";
+
 import Checkbox from "material-ui/Checkbox/Checkbox";
 
 import { canManage, canDelete, canUpdate, canCreate } from "d2-ui-components/auth";
-import { list } from "../../models/datasets";
+import { list, getDashboardId } from "../../models/datasets";
+import { goToDhis2Url } from "../../utils/routes";
 
 class CampaignConfigurator extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
         config: PropTypes.object.isRequired,
+        snackbar: PropTypes.object.isRequired,
     };
 
     state = {
@@ -76,6 +79,7 @@ class CampaignConfigurator extends React.Component {
             name: "dashboard",
             text: i18n.t("Go to Dashboard"),
             multiple: false,
+            onClick: dataSet => this.goToDashboard(dataSet),
         },
         {
             name: "download",
@@ -84,6 +88,15 @@ class CampaignConfigurator extends React.Component {
             multiple: false,
         },
     ];
+
+    goToDashboard = dataSet => {
+        const dashboardId = getDashboardId(dataSet, this.props.config);
+        if (dashboardId) {
+            goToDhis2Url(`/dhis-web-dashboard/#/${dashboardId}`);
+        } else {
+            this.props.snackbar.error(i18n.t("Cannot find dashboard associated to the campaign"));
+        }
+    };
 
     onCreate = () => {
         this.props.history.push("/campaign-configuration/new");
@@ -142,4 +155,4 @@ const styles = {
     checkboxIcon: { marginRight: 8 },
 };
 
-export default CampaignConfigurator;
+export default withSnackbar(CampaignConfigurator);

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -1,4 +1,4 @@
-import { list } from "../datasets";
+import { list, getDashboardId } from "../datasets";
 import { getD2Stub } from "../../utils/testing";
 import metadataConfig from "./config-mock";
 
@@ -101,6 +101,27 @@ describe("DataSets", () => {
                     filter: [`id:in:[${testIds[0]},${testIds[2]}]`],
                 });
             });
+        });
+    });
+
+    describe("getDashboardId", () => {
+        it("returns ID for related dashboard", () => {
+            const dataSet = {
+                attributeValues: [
+                    { value: "545", attribute: { code: "SOME_CODE" } },
+                    { value: "1234", attribute: { code: "RVC_DASHBOARD_ID" } },
+                ],
+            };
+
+            expect(getDashboardId(dataSet, metadataConfig)).toEqual("1234");
+        });
+
+        it("returns nothing if there is no dashboard related", () => {
+            const dataSet = {
+                attributeValues: [{ value: "1234", attribute: { code: "SOME_OTHER_CODE" } }],
+            };
+
+            expect(getDashboardId(dataSet, metadataConfig)).toBeFalsy();
         });
     });
 });

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -60,3 +60,10 @@ async function getByAttribute(config, d2) {
         .map(el => el.id);
     return ids;
 }
+
+export function getDashboardId(dataSet, config) {
+    return _(dataSet.attributeValues || [])
+        .filter(av => av.attribute.code === config.attributeCodeForDashboard)
+        .map(av => av.value)
+        .first();
+}

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -1,0 +1,7 @@
+export function goToDhis2Url(path) {
+    const { REACT_APP_DHIS2_BASE_URL } = process.env;
+    const clean = s => s.replace(/^\//, "");
+    const url = [clean(REACT_APP_DHIS2_BASE_URL), clean(path)].join("/");
+    window.location = url;
+    return null;
+}

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -1,7 +1,6 @@
 export function goToDhis2Url(path) {
-    const { REACT_APP_DHIS2_BASE_URL } = process.env;
-    const clean = s => s.replace(/^\//, "");
-    const url = [clean(REACT_APP_DHIS2_BASE_URL), clean(path)].join("/");
+    const baseUrl = process.env.REACT_APP_DHIS2_BASE_URL || "";
+    const url = [baseUrl.replace(/\/$/, ""), path.replace(/^\//, "")].join("/");
     window.location = url;
     return null;
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #67 

### :memo: Implementation

- Check `dataSet.attributeValues` to look for the relationship with the dashboard ID.
- Added generic `utils.routes.goToDhis2Url(path)`
- Since it was related, I've refactored the landing/root redirects. As it was, it first redirected to the internall app route, then to DHIS2 route (from Root). If there you pressed back, it would go that the internal route again, so the user is caught in a loop. Now it redirects directly from LandingPage.