### PR TITLE
Extract page header to shared folder, utilize in campaign-configurator

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-03-11T11:33:36.984Z\n"
-"PO-Revision-Date: 2019-03-11T11:33:36.984Z\n"
+"POT-Creation-Date: 2019-03-13T12:10:59.421Z\n"
+"PO-Revision-Date: 2019-03-13T12:10:59.421Z\n"
 
 msgid "Vaccination"
 msgstr ""
@@ -80,6 +80,9 @@ msgstr ""
 msgid "Only my campaigns"
 msgstr ""
 
+msgid "Campaigns"
+msgstr ""
+
 msgid "Organisation Units"
 msgstr ""
 
@@ -132,13 +135,13 @@ msgstr ""
 msgid "New vaccination campaign"
 msgstr ""
 
-msgid "Back"
-msgstr ""
-
 msgid "Cancel"
 msgstr ""
 
 msgid "Ok"
+msgstr ""
+
+msgid "Back"
 msgstr ""
 
 msgid "Field cannot be blank"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-03-11T11:33:36.984Z\n"
+"POT-Creation-Date: 2019-03-13T12:10:59.421Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,6 +80,9 @@ msgstr "No hay ningún tablero asociado a la campaña"
 msgid "Only my campaigns"
 msgstr "Solo mis campañas"
 
+msgid "Campaigns"
+msgstr "Campañas"
+
 msgid "Organisation Units"
 msgstr "Unidades organizativas"
 
@@ -142,14 +145,14 @@ msgstr ""
 msgid "New vaccination campaign"
 msgstr "Nueva campaña"
 
-msgid "Back"
-msgstr "Atrás"
-
 msgid "Cancel"
 msgstr "Cancelar"
 
 msgid "Ok"
 msgstr "Aceptar"
+
+msgid "Back"
+msgstr "Atrás"
 
 msgid "Field cannot be blank"
 msgstr "El campo no puede estar vacío"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-03-11T11:33:36.984Z\n"
+"POT-Creation-Date: 2019-03-13T12:10:59.421Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,6 +80,9 @@ msgstr ""
 msgid "Only my campaigns"
 msgstr ""
 
+msgid "Campaigns"
+msgstr ""
+
 msgid "Organisation Units"
 msgstr ""
 
@@ -133,13 +136,13 @@ msgstr ""
 msgid "New vaccination campaign"
 msgstr ""
 
-msgid "Back"
-msgstr ""
-
 msgid "Cancel"
 msgstr ""
 
 msgid "Ok"
+msgstr ""
+
+msgid "Back"
 msgstr ""
 
 msgid "Field cannot be blank"

--- a/src/components/campaign-configurator/CampaignConfigurator.jsx
+++ b/src/components/campaign-configurator/CampaignConfigurator.jsx
@@ -5,6 +5,7 @@ import { ObjectsTable, withSnackbar } from "d2-ui-components";
 
 import Checkbox from "material-ui/Checkbox/Checkbox";
 
+import PageHeader from "../shared/PageHeader";
 import { canManage, canDelete, canUpdate, canCreate } from "d2-ui-components/auth";
 import { list, getDashboardId } from "../../models/datasets";
 import { goToDhis2Url } from "../../utils/routes";
@@ -127,11 +128,16 @@ class CampaignConfigurator extends React.Component {
         return list(config, ...listArgs);
     };
 
+    backHome = () => {
+        this.props.history.push("/");
+    };
+
     render() {
         const { d2 } = this.props;
 
         return (
-            <div>
+            <React.Fragment>
+                <PageHeader title={i18n.t("Campaigns")} onBackClick={this.backHome} />
                 <ObjectsTable
                     d2={d2}
                     model={d2.models.dataSet}
@@ -145,7 +151,7 @@ class CampaignConfigurator extends React.Component {
                     customFiltersComponent={this.renderCustomFilters}
                     customFilters={this.state.filters}
                 />
-            </div>
+            </React.Fragment>
         );
     }
 }

--- a/src/components/campaign-configurator/CampaignConfigurator.jsx
+++ b/src/components/campaign-configurator/CampaignConfigurator.jsx
@@ -138,19 +138,21 @@ class CampaignConfigurator extends React.Component {
         return (
             <React.Fragment>
                 <PageHeader title={i18n.t("Campaigns")} onBackClick={this.backHome} />
-                <ObjectsTable
-                    d2={d2}
-                    model={d2.models.dataSet}
-                    columns={this.columns}
-                    detailsFields={this.detailsFields}
-                    pageSize={20}
-                    initialSorting={this.initialSorting}
-                    actions={this.actions}
-                    onCreate={this.canCreateDataSets ? this.onCreate : null}
-                    list={this.list}
-                    customFiltersComponent={this.renderCustomFilters}
-                    customFilters={this.state.filters}
-                />
+                <div style={styles.objectsTableContainer}>
+                    <ObjectsTable
+                        model={d2.models.dataSet}
+                        columns={this.columns}
+                        d2={d2}
+                        detailsFields={this.detailsFields}
+                        pageSize={20}
+                        initialSorting={this.initialSorting}
+                        actions={this.actions}
+                        onCreate={this.canCreateDataSets ? this.onCreate : null}
+                        list={this.list}
+                        customFiltersComponent={this.renderCustomFilters}
+                        customFilters={this.state.filters}
+                    />
+                </div>
             </React.Fragment>
         );
     }
@@ -159,6 +161,7 @@ class CampaignConfigurator extends React.Component {
 const styles = {
     checkbox: { float: "left", width: "25%", paddingTop: 18, marginLeft: 30 },
     checkboxIcon: { marginRight: 8 },
+    objectsTableContainer: { marginTop: -10 },
 };
 
 export default withSnackbar(CampaignConfigurator);

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -7,7 +7,7 @@ import Campaign from "models/campaign";
 import DbD2 from "models/db-d2";
 
 import Wizard from "../wizard/Wizard";
-import FormHeading from "./FormHeading";
+import PageHeader from "../shared/PageHeader";
 import OrganisationUnitsStep from "../steps/organisation-units/OrganisationUnitsStep";
 import SaveStep from "../steps/save/SaveStep";
 import { getValidationMessages } from "../../utils/validations";
@@ -137,7 +137,7 @@ dataset and all the metadata associated with this vaccination campaign`),
                         "You are about to exit the campaign creation wizard. All your changes will be lost. Are you sure?"
                     )}
                 />
-                <FormHeading
+                <PageHeader
                     title={i18n.t("New vaccination campaign")}
                     onBackClick={this.cancelSave}
                 />

--- a/src/components/shared/PageHeader.jsx
+++ b/src/components/shared/PageHeader.jsx
@@ -6,7 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
 import Icon from "@material-ui/core/Icon";
 
-const iconStyle = { marginBottom: 7 };
+const iconStyle = { paddingTop: 10, marginBottom: 5 };
 
 function PageHeader({ variant, title, onBackClick }) {
     return (
@@ -20,7 +20,7 @@ function PageHeader({ variant, title, onBackClick }) {
                 <Icon color="primary">arrow_back</Icon>
             </IconButton>
 
-            <Typography variant={variant} gutterBottom style={{ display: "inline-block" }}>
+            <Typography variant={variant} style={{ display: "inline-block", fontWeight: 300 }}>
                 {title}
             </Typography>
         </div>

--- a/src/components/shared/PageHeader.jsx
+++ b/src/components/shared/PageHeader.jsx
@@ -8,7 +8,7 @@ import Icon from "@material-ui/core/Icon";
 
 const iconStyle = { marginBottom: 7 };
 
-function FormHeading({ variant, title, onBackClick }) {
+function PageHeader({ variant, title, onBackClick }) {
     return (
         <div>
             <IconButton
@@ -27,14 +27,14 @@ function FormHeading({ variant, title, onBackClick }) {
     );
 }
 
-FormHeading.propTypes = {
+PageHeader.propTypes = {
     variant: PropTypes.string,
     title: PropTypes.string.isRequired,
     onBackClick: PropTypes.func.isRequired,
 };
 
-FormHeading.defaultProps = {
+PageHeader.defaultProps = {
     variant: "h5",
 };
 
-export default FormHeading;
+export default PageHeader;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #45 ?

### :memo: Implementation-
@tokland I remember we discussed having all components in self-contained folders which I agree on, but how would you handle a situation like this using that standard? This page header component will eventually be used in at least 2 more pages I believe. Do you agree with extracting it to a shared folder or should we clone it and place it inside each page component folder?


### :art: Screenshots
![image](https://user-images.githubusercontent.com/15323369/54278885-ff76de00-4593-11e9-83f5-c4a03863eca9.png)
