### PR TITLE
Live validation on disaggregation (current: select_at_least_one_option)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-09T20:54:37.763Z\n"
-"PO-Revision-Date: 2019-04-09T20:54:37.763Z\n"
+"POT-Creation-Date: 2019-04-11T10:13:25.271Z\n"
+"PO-Revision-Date: 2019-04-11T10:13:25.271Z\n"
 
 msgid "Campaign Configuration"
 msgstr ""
@@ -190,4 +190,7 @@ msgid "Field {{field}} cannot be blank if field {{other}} is set"
 msgstr ""
 
 msgid "Select at least one antigen"
+msgstr ""
+
+msgid "You must select at least one option of the category"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,15 +1,12 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-10T08:21:00.189Z\n"
+"POT-Creation-Date: 2019-04-11T10:13:25.271Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-
-msgid "Vaccination"
-msgstr "Vacunación"
 
 msgid "Campaign Configuration"
 msgstr "Configurador de campaña"
@@ -205,3 +202,7 @@ msgstr "El campo {{field}} no puede estar vacío si {{other}} tiene un valor"
 
 msgid "Select at least one antigen"
 msgstr "Seleccione al menos un antígeno"
+
+msgid "You must select at least one option of the category"
+msgstr "Debes seleccionar al menos una opción de la categoría"
+

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,15 +1,12 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-10T08:21:00.189Z\n"
+"POT-Creation-Date: 2019-04-11T10:13:25.271Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-
-msgid "Vaccination"
-msgstr ""
 
 msgid "Campaign Configuration"
 msgstr ""
@@ -194,4 +191,7 @@ msgid "Field {{field}} cannot be blank if field {{other}} is set"
 msgstr ""
 
 msgid "Select at least one antigen"
+msgstr ""
+
+msgid "You must select at least one option of the category"
 msgstr ""

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -16,12 +16,15 @@ import GeneralInfoStep from "../steps/general-info/GeneralInfoStep";
 import AntigenSelectionStep from "../steps/antigen-selection/AntigenSelectionStep";
 import ConfirmationDialog from "../confirmation-dialog/ConfirmationDialog";
 import DisaggregationStep from "../steps/disaggregation/DisaggregationStep";
+import { memoize } from "../../utils/memoize";
+import { withSnackbar } from "d2-ui-components";
 
 class CampaignWizard extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
         history: PropTypes.object.isRequired,
         config: PropTypes.object.isRequired,
+        snackbar: PropTypes.object.isRequired,
     };
 
     constructor(props) {

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
 import { withRouter } from "react-router";
+import _ from "lodash";
 
 import Campaign from "models/campaign";
 import DbD2 from "models/db-d2";
@@ -70,7 +71,8 @@ Only organisation units of level 5 (Health site) can be selected`),
                 key: "disaggregation",
                 label: i18n.t("Indicators Configuration"),
                 component: DisaggregationStep,
-                validationKeys: [],
+                validationKeys: ["antigensDisaggregation"],
+                validationKeysLive: ["antigensDisaggregation"],
                 description: i18n.t(`Select indicators and categories for each antigen`),
                 help: i18n.t(`Select indicators and categories for each antigen`),
             },
@@ -99,9 +101,14 @@ dataset and all the metadata associated with this vaccination campaign`),
         this.setState({ dialogOpen: false });
     };
 
-    onChange = campaign => {
-        this.setState({ campaign });
-    };
+    onChange = memoize(step => campaign => {
+        const errors = getValidationMessages(campaign, step.validationKeysLive || []);
+        if (_(errors).isEmpty()) {
+            this.setState({ campaign });
+        } else {
+            this.props.snackbar.error(errors.join("\n"));
+        }
+    });
 
     onStepChangeRequest = currentStep => {
         return getValidationMessages(this.state.campaign, currentStep.validationKeys);
@@ -117,7 +124,7 @@ dataset and all the metadata associated with this vaccination campaign`),
             props: {
                 d2,
                 campaign,
-                onChange: this.onChange,
+                onChange: this.onChange(step),
             },
         }));
 
@@ -153,4 +160,4 @@ dataset and all the metadata associated with this vaccination campaign`),
     }
 }
 
-export default withRouter(CampaignWizard);
+export default withSnackbar(withRouter(CampaignWizard));

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -1,5 +1,6 @@
 import { DataElement, CategoryCombo } from "./db.types";
 import _, { Dictionary } from "lodash";
+const fp = require("lodash/fp");
 import { AntigenDisaggregation } from "./AntigensDisaggregation";
 import { MetadataConfig } from "./config";
 import { Antigen } from "./campaign";
@@ -54,35 +55,52 @@ export type CustomFormMetadata = {
 };
 
 type AntigensDisaggregationData = {
-    [code: string]: AntigenDisaggregation;
+    antigens: Antigen[];
+    disaggregation: { [code: string]: AntigenDisaggregation };
 };
 
 export class AntigensDisaggregation {
     constructor(private config: MetadataConfig, public data: AntigensDisaggregationData) {}
 
     static build(config: MetadataConfig, antigens: Antigen[]): AntigensDisaggregation {
-        const initial = new AntigensDisaggregation(config, {});
+        const initial = new AntigensDisaggregation(config, { antigens: [], disaggregation: {} });
         return initial.setAntigens(antigens);
     }
 
     public setAntigens(antigens: Antigen[]): AntigensDisaggregation {
-        const disaggregationByCode = _.keyBy(this.data, "code");
-        const dataUpdated = _(antigens)
+        const disaggregationByCode = _.keyBy(this.data.disaggregation, "code");
+        const disaggregationUpdated = _(antigens)
             .keyBy("code")
             .mapValues(
                 antigen => disaggregationByCode[antigen.code] || this.buildForAntigen(antigen.code)
             )
             .value();
+        const dataUpdated = { antigens, disaggregation: disaggregationUpdated };
         return new AntigensDisaggregation(this.config, dataUpdated);
     }
 
     public forAntigen(antigen: Antigen): AntigenDisaggregation | undefined {
-        return this.data[antigen.code];
+        return this.data.disaggregation[antigen.code];
     }
 
     public set(path: (number | string)[], value: any): AntigensDisaggregation {
-        const dataUpdated = _.set(this.data, path, value);
+        const dataUpdated = fp.set(["disaggregation", ...path], value, this.data);
         return new AntigensDisaggregation(this.config, dataUpdated);
+    }
+
+    public validate(): Array<{ key: string; namespace: object }> {
+        const errors = _(this.getEnabled())
+            .flatMap(antigen => antigen.dataElements)
+            .flatMap(dataElement => dataElement.categories)
+            .map(category =>
+                _(category.categoryOptions).isEmpty()
+                    ? { key: "select_at_least_one_option_for_category", namespace: {} }
+                    : null
+            )
+            .compact()
+            .value();
+
+        return errors;
     }
 
     static getCategories(
@@ -116,8 +134,8 @@ export class AntigensDisaggregation {
         });
     }
 
-    getEnabled(antigens: Antigen[]): AntigenDisaggregationEnabled {
-        const antigenDisaggregations = _(antigens)
+    getEnabled(): AntigenDisaggregationEnabled {
+        const antigenDisaggregations = _(this.data.antigens)
             .map(this.forAntigen.bind(this))
             .compact()
             .value();
@@ -192,8 +210,8 @@ export class AntigensDisaggregation {
         return res;
     }
 
-    public async getCustomFormMetadata(db: DbD2, antigens: Antigen[]): Promise<CustomFormMetadata> {
-        const data = _.flatMap(this.getEnabled(antigens), ({ dataElements, antigen }) => {
+    public async getCustomFormMetadata(db: DbD2): Promise<CustomFormMetadata> {
+        const data = _.flatMap(this.getEnabled(), ({ dataElements, antigen }) => {
             return dataElements.map(({ code, categories }) => ({
                 antigenCode: antigen.code,
                 dataElementCode: code,

--- a/src/models/DataSetCustomForm.ts
+++ b/src/models/DataSetCustomForm.ts
@@ -31,10 +31,7 @@ export class DataSetCustomForm {
     constructor(public campaign: Campaign, private metadata: CustomFormMetadata) {}
 
     static async build(campaign: Campaign, db: DbD2): Promise<DataSetCustomForm> {
-        const metadata = await campaign.antigensDisaggregation.getCustomFormMetadata(
-            db,
-            campaign.antigens
-        );
+        const metadata = await campaign.antigensDisaggregation.getCustomFormMetadata(db);
         return new DataSetCustomForm(campaign, metadata);
     }
 

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -51,7 +51,14 @@ export default class Campaign {
     }
 
     public validate() {
-        const { organisationUnits, name, startDate, endDate, antigens } = this.data;
+        const {
+            organisationUnits,
+            name,
+            startDate,
+            endDate,
+            antigens,
+            antigensDisaggregation,
+        } = this.data;
 
         const allOrgUnitsInAcceptedLevels = _(organisationUnits).every(ou =>
             _(this.selectableLevels).includes(
@@ -96,6 +103,8 @@ export default class Campaign {
                       key: "no_antigens_selected",
                   }
                 : null,
+
+            antigensDisaggregation: antigensDisaggregation.validate(),
         });
     }
 
@@ -186,7 +195,7 @@ export default class Campaign {
     }
 
     public getEnabledAntigensDisaggregation(): AntigenDisaggregationEnabled {
-        return this.antigensDisaggregation.getEnabled(this.antigens);
+        return this.antigensDisaggregation.getEnabled();
     }
 
     /* Save */

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -11,9 +11,14 @@ const translations = {
         i18n.t("Field {{field}} cannot be blank if field {{other}} is set", namespace),
 
     no_antigens_selected: () => i18n.t("Select at least one antigen"),
+
+    select_at_least_one_option_for_category: () =>
+        i18n.t("You must select at least one option of the category"),
 };
 
 export function getValidationMessages(campaign, validationKeys) {
+    if (_(validationKeys).isEmpty()) return [];
+
     const validationObj = campaign.validate();
 
     return _(validationObj)
@@ -25,7 +30,7 @@ export function getValidationMessages(campaign, validationKeys) {
             if (translation) {
                 return i18n.t(translation(error.namespace));
             } else {
-                return `Missing translations: ${error.key}`;
+                return `Missing translation: ${error.key}`;
             }
         })
         .value();


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Works on #63

Tasks in this PR:

- If they are mandatory fields, check that at least one option has been selected by the user.

### :memo: Implementation

- Until now, validations on the campaign were performed when trying to advance the step. In this case we needed live validation, so I've added a new key in CampaignWizard: `validationKeysLive`.

### :art: Screenshots

![Screenshot from 2019-04-11 12-15-24](https://user-images.githubusercontent.com/24643/55950209-ad89ac80-5c54-11e9-85f8-c3f16aa96a28.png)