### PR TITLE
Feature/refine form styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "scripts": {
         "prestart": "yarn localize && d2-manifest package.json manifest.webapp",
         "start": "BROWSER=false PORT=${PORT:-8081} react-scripts start",
-        "prebuild": "yarn test",
+        "prebuild": "yarn localize && yarn test",
         "code-quality": "yarn lint && yarn prettify && yarn test",
-        "build": "rm -rf build/ && yarn localize && d2-manifest package.json manifest.webapp && react-scripts build && yarn run manifest && cp -r i18n icon.png build",
+        "build": "rm -rf build/ && d2-manifest package.json manifest.webapp && react-scripts build && yarn run manifest && cp -r i18n icon.png build",
         "build-webapp": "yarn build && rm -f $npm_package_name.zip && cd build && zip -r ../$npm_package_name.zip *",
         "test": "jest",
         "lint": "eslint src cypress",

--- a/src/models/DataSetCustomForm.ts
+++ b/src/models/DataSetCustomForm.ts
@@ -204,14 +204,17 @@ export class DataSetCustomForm {
                 "div",
                 {},
                 _.flatMap(groups, ({ title, dataElements }) => [
-                    h("div", { class: "dataelement-group" }, title),
-                    h(
-                        "div",
-                        { class: "formSection sectionContainer" },
-                        _.flatMap(this.getDataElementByCategoryOptionsLists(dataElements), data =>
-                            this.renderGroupWrapper(disaggregation.antigen, data)
-                        )
-                    ),
+                    h("div", { class: "dataelement-group" }, [
+                        h("div", { class: "title" }, title),
+                        h(
+                            "div",
+                            { class: "formSection sectionContainer" },
+                            _.flatMap(
+                                this.getDataElementByCategoryOptionsLists(dataElements),
+                                data => this.renderGroupWrapper(disaggregation.antigen, data)
+                            )
+                        ),
+                    ]),
                 ])
             )
         );
@@ -484,8 +487,8 @@ const css = `
         white-space: nowrap;
         padding-top: 2px !important;
         padding-bottom: 2px !important;
-        padding-left: 10px;
-        padding-right: 10px;
+        padding-left: 5px;
+        padding-right: 5px;
         word-wrap: break-word;
     }
 
@@ -523,9 +526,13 @@ const css = `
     }
 
     .dataelement-group {
+        margin-bottom: 20px
+    }
+
+    .dataelement-group .title {
         color: #544;
         font-size: 1.2em;
         font-weight: bold;
-        margin: 5px 0px;
+        margin: 5px 0px 5px 0px;
     }
 `;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #69 

### :memo: Implementation

- I've checked the split code for NRC, and there we have some restrictions because initially the split had  to be done from the automatic form, so we only had the HTML to work. Here, we have custom form, so I've used a different approach, do the hard work already in the custom form generation: 
  - Render a table with all categories.
  - Render another second bunch of tables with the first category (age range) split, one table per age range.
  - The code run on the client calculates the width of those tables in the group and leaves only visible the one that fits. 
  - I could write a generic code that creates more split tables, but it seems overkill on our case (max: 2 gender * 3 displacement = 6 cocs in row). But it can be done if necessary.

### :art: Screenshots

![Screenshot from 2019-04-12 17-30-21](https://user-images.githubusercontent.com/24643/56049177-31bd5c00-5d49-11e9-949e-1ff303d907e2.png)