### PR TITLE
Dynamically check for associated teams for selected OrgUnit

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-11T10:13:25.271Z\n"
-"PO-Revision-Date: 2019-04-11T10:13:25.271Z\n"
+"POT-Creation-Date: 2019-04-13T12:17:15.119Z\n"
+"PO-Revision-Date: 2019-04-13T12:17:15.119Z\n"
 
 msgid "Campaign Configuration"
 msgstr ""
@@ -164,6 +164,9 @@ msgid "Start date"
 msgstr ""
 
 msgid "End Date"
+msgstr ""
+
+msgid "This organisation unit has no teams associated"
 msgstr ""
 
 msgid "Error saving campaign"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-11T10:13:25.271Z\n"
+"POT-Creation-Date: 2019-04-13T12:17:15.119Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -182,6 +182,9 @@ msgstr "Fecha de inicio"
 
 msgid "End Date"
 msgstr "Fecha de fin"
+
+msgid "This organisation unit has no teams associated"
+msgstr "Esta unidad organizativa no tiene equipos asociados"
 
 msgid "Error saving campaign"
 msgstr "Se produjo un error al guardar la campaña"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-11T10:13:25.271Z\n"
+"POT-Creation-Date: 2019-04-13T12:17:15.119Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,6 +165,9 @@ msgid "Start date"
 msgstr ""
 
 msgid "End Date"
+msgstr ""
+
+msgid "This organisation unit has no teams associated"
 msgstr ""
 
 msgid "Error saving campaign"

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { OrgUnitsSelector } from "d2-ui-components";
+import { OrgUnitsSelector, withSnackbar } from "d2-ui-components";
 import _ from "lodash";
 import "./OrganisationUnitsStep.css";
+import i18n from "../../../locales";
 
 /*
     HACK: Use css to hide all selector boxes in tree except for those of level 6.
@@ -15,6 +16,7 @@ class OrganisationUnitsStep extends React.Component {
         d2: PropTypes.object.isRequired,
         campaign: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
+        snackbar: PropTypes.object.isRequired,
     };
 
     controls = {
@@ -23,7 +25,7 @@ class OrganisationUnitsStep extends React.Component {
         selectAll: false,
     };
 
-    setOrgUnits = orgUnitsPaths => {
+    setOrgUnits = async orgUnitsPaths => {
         const orgUnits = orgUnitsPaths.map(path => ({
             id: _.last(path.split("/")),
             level: path.split("/").length - 1,
@@ -32,6 +34,14 @@ class OrganisationUnitsStep extends React.Component {
         const orgUnitsForAcceptedLevels = orgUnits.filter(ou =>
             this.props.campaign.selectableLevels.includes(ou.level)
         );
+        const organisationUnitsTeams = await this.props.campaign.validateTeamsForOrganisationUnits(
+            orgUnitsForAcceptedLevels
+        );
+        if (organisationUnitsTeams && !_.last(organisationUnitsTeams).hasTeams) {
+            return this.props.snackbar.error(
+                i18n.t("This organisation unit has no teams associated")
+            );
+        }
         const newCampaign = this.props.campaign.setOrganisationUnits(orgUnitsForAcceptedLevels);
         this.props.onChange(newCampaign);
     };
@@ -51,4 +61,4 @@ class OrganisationUnitsStep extends React.Component {
     }
 }
 
-export default OrganisationUnitsStep;
+export default withSnackbar(OrganisationUnitsStep);

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -140,7 +140,10 @@ export default class Campaign {
 
     public async validateTeamsForOrganisationUnits(organisationUnits: OrganisationUnitPathOnly[]) {
         if (_.isEmpty(organisationUnits)) return;
-        return this.db.validateTeamsForOrganisationUnits(organisationUnits);
+        return this.db.validateTeamsForOrganisationUnits(
+            organisationUnits,
+            this.config.categoryCodeForTeams
+        );
     }
 
     /* Name */

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -138,6 +138,11 @@ export default class Campaign {
         return this.data.organisationUnits;
     }
 
+    public async validateTeamsForOrganisationUnits(organisationUnits: OrganisationUnitPathOnly[]) {
+        if (_.isEmpty(organisationUnits)) return;
+        return this.db.validateTeamsForOrganisationUnits(organisationUnits);
+    }
+
     /* Name */
 
     public setName(name: string): Campaign {

--- a/src/models/dashboard-items.js
+++ b/src/models/dashboard-items.js
@@ -126,10 +126,12 @@ export function buildDashboardItems(
 }
 
 const dataMapper = (dataList, filterList) =>
-    dataList.data.filter(({ code }) => _.includes(filterList, code)).map(({ id }) => ({
-        dataDimensionItemType: dataList.type,
-        [dataList.key]: { id },
-    }));
+    dataList.data
+        .filter(({ code }) => _.includes(filterList, code))
+        .map(({ id }) => ({
+            dataDimensionItemType: dataList.type,
+            [dataList.key]: { id },
+        }));
 
 export function itemsMetadataConstructor(dashboardItemsMetadata) {
     const {
@@ -141,21 +143,19 @@ export function itemsMetadataConstructor(dashboardItemsMetadata) {
     const { tables, charts } = dashboardItemsConfig;
 
     const tableElements = _(tables)
-        .map(
-            (item, key) =>
-                item.dataType === "INDICATOR"
-                    ? [key, dataMapper(indicators, item.elements)]
-                    : [key, dataMapper(dataElements, item.elements)]
+        .map((item, key) =>
+            item.dataType === "INDICATOR"
+                ? [key, dataMapper(indicators, item.elements)]
+                : [key, dataMapper(dataElements, item.elements)]
         )
         .fromPairs()
         .value();
 
     const chartElements = _(charts)
-        .map(
-            (item, key) =>
-                item.dataType === "INDICATOR"
-                    ? [key, dataMapper(indicators, item.elements)]
-                    : [key, dataMapper(dataElements, item.elements)]
+        .map((item, key) =>
+            item.dataType === "INDICATOR"
+                ? [key, dataMapper(indicators, item.elements)]
+                : [key, dataMapper(dataElements, item.elements)]
         )
         .fromPairs()
         .value();

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -196,22 +196,23 @@ export default class DbD2 {
             .uniq()
             .value()
             .join(",");
-        
-            const { categoryOptions } = await this.api.get(
-                "/metadata",
-                {
-                    "categoryOptions:fields": "id,organisationUnits",
-                    "categoryOptions:filter": `organisationUnits.id:in:[${allAncestorsIds}]`, //Missing categoryTeamCode
-                }
-            );
-        
+
+        const { categoryOptions } = await this.api.get("/metadata", {
+            "categoryOptions:fields": "id,organisationUnits",
+            "categoryOptions:filter": `organisationUnits.id:in:[${allAncestorsIds}]`, //Missing categoryTeamCode
+        });
+
         const hasTeams = (path: string) => {
             if (!categoryOptions) return false;
-            const has = categoryOptions.some((cat: CategoryOption) => cat.organisationUnits.some((ou: OrganisationUnit) => path.includes(ou.id)));
+            const has = categoryOptions.some((cat: CategoryOption) =>
+                cat.organisationUnits.some((ou: OrganisationUnit) => path.includes(ou.id))
+            );
             return has;
-        }
+        };
 
-        return _(organisationUnits).map(ou => ({ id: ou.id, hasTeams: hasTeams(ou.path)})).value();
+        return _(organisationUnits)
+            .map(ou => ({ id: ou.id, hasTeams: hasTeams(ou.path) }))
+            .value();
     }
 
     public async getCategoryOptionsByCategoryCode(code: string): Promise<CategoryOption[]> {
@@ -312,7 +313,7 @@ export default class DbD2 {
             .value()
             .join(",");
 
-        const orgUnitsId = _(organisationUnitsPathOnly).map('id');
+        const orgUnitsId = _(organisationUnitsPathOnly).map("id");
         const dashboardItems = [dashboardItemsConfig.charts, dashboardItemsConfig.tables];
         const elements = _(dashboardItems)
             .values()
@@ -324,21 +325,24 @@ export default class DbD2 {
         const allDataElementCodes = elements["DATA_ELEMENT"].join(",");
         const allIndicatorCodes = elements["INDICATOR"].join(",");
         const antigenCodes = antigens.map(an => an.code);
-        const { categories, dataElements, indicators, categoryOptions, organisationUnits: organisationUnitsWithName } = await this.api.get(
-            "/metadata",
-            {
-                "categories:fields": "id,categoryOptions[id,code,name]",
-                "categories:filter": `code:in:[${dashboardItemsConfig.antigenCategoryCode}]`,
-                "dataElements:fields": "id,code",
-                "dataElements:filter": `code:in:[${allDataElementCodes}]`,
-                "indicators:fields": "id,code",
-                "indicators:filter": `code:in:[${allIndicatorCodes}]`,
-                "categoryOptions:fields": "id,categories[id,code],organisationUnits",
-                "categoryOptions:filter": `organisationUnits.id:in:[${allAncestorsIds}]`, //Missing categoryTeamCode
-                "organisationUnits:fields": "id,displayName,path",
-                "organisationUnits:filter": `id:in:[${orgUnitsId}]`,
-            }
-        );
+        const {
+            categories,
+            dataElements,
+            indicators,
+            categoryOptions,
+            organisationUnits: organisationUnitsWithName,
+        } = await this.api.get("/metadata", {
+            "categories:fields": "id,categoryOptions[id,code,name]",
+            "categories:filter": `code:in:[${dashboardItemsConfig.antigenCategoryCode}]`,
+            "dataElements:fields": "id,code",
+            "dataElements:filter": `code:in:[${allDataElementCodes}]`,
+            "indicators:fields": "id,code",
+            "indicators:filter": `code:in:[${allIndicatorCodes}]`,
+            "categoryOptions:fields": "id,categories[id,code],organisationUnits",
+            "categoryOptions:filter": `organisationUnits.id:in:[${allAncestorsIds}]`, //Missing categoryTeamCode
+            "organisationUnits:fields": "id,displayName,path",
+            "organisationUnits:filter": `id:in:[${orgUnitsId}]`,
+        });
 
         const { id: antigenCategory } = categories[0];
         const antigensMeta = _.filter(categories[0].categoryOptions, op =>

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -48,6 +48,7 @@ export interface CategoryOption {
     id: string;
     code: string;
     displayName: string;
+    organisationUnits: OrganisationUnit[];
 }
 
 export interface CategoryOptionGroup {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** #82

### :memo: Implementation
On OU selection it checks for the existence of associated teams and either permits selection or throws a snackbar error message and prevents OU selection.

### :art: Screenshots
![image](https://user-images.githubusercontent.com/15323369/56079666-dbf3bd00-5df7-11e9-8beb-107350a9080e.png)

### :fire: Is there anything the reviewer should know to test it?
Based of `feature/enhance-dash-82` branch
