### PR TITLE
Use ISO strings without time-zone for opening/closing dataset dates

### DIFF
--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -10,7 +10,7 @@ import { generateUid } from "d2/uid";
 import { DataSet, Response } from "./db.types";
 import { PaginatedObjects, OrganisationUnitPathOnly } from "./db.types";
 import DbD2 from "./db-d2";
-import { getDaysRange } from "../utils/date";
+import { getDaysRange, toISOStringNoTZ } from "../utils/date";
 import { MetadataConfig } from "./config";
 import { AntigenDisaggregationEnabled, getDataElements } from "./AntigensDisaggregation";
 import { TargetPopulation, TargetPopulationData } from "./TargetPopulation";
@@ -293,8 +293,8 @@ export default class Campaign {
             }));
 
             const dataInputPeriods = getDaysRange(startDate, endDate).map(date => ({
-                openingDate: startDate.toISOString(),
-                closingDate: endDate.toISOString(),
+                openingDate: toISOStringNoTZ(startDate),
+                closingDate: toISOStringNoTZ(endDate),
                 period: { id: date.format("YYYYMMDD") },
             }));
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,9 @@
 import moment, { Moment } from "moment";
 
+export function toISOStringNoTZ(date: Moment) {
+    return date.format("YYYY-MM-DDTHH:mm:ss");
+}
+
 export function formatDateLong(inputDate: string | Date | Moment | undefined): string {
     if (!inputDate) {
         return "";


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #116

### :memo: Implementation

This one was tricky. It turns out that DHIS2 DB uses naked dates:
```
msf230=# \d+ datainputperiod;
openingdate       | timestamp without time zone
```

So the server does not understand UTC dates, everything is assumed to be local. That why in the server guide says: `It may be necessary to reconfigure the time zone of the server to match the time zone of the location which the DHIS2 server will be covering`.

So there is no real solution to this, even though we can prevent the particular problem of the issue setting start/end dates with ISO dates without timezone. This is the approach in this PR.

### :fire: Is there anything the reviewer should know to test it?

When testing in a local server, this problem was not reproducible, because server and client time zone is the same. So it must be tested against local and devX servers.
