### PR TITLE
Refactor campaign save use metadata

### DIFF
--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -4,7 +4,6 @@ const fp = require("lodash/fp");
 import { AntigenDisaggregation } from "./AntigensDisaggregation";
 import { MetadataConfig } from "./config";
 import { Antigen } from "./campaign";
-import DbD2 from "./db-d2";
 import "../utils/lodash-mixins";
 
 export interface AntigenDisaggregation {
@@ -106,7 +105,7 @@ export class AntigensDisaggregation {
 
     static getCategories(
         config: MetadataConfig,
-        dataElementConfig: MetadataConfig["dataElements"][0],
+        dataElementConfig: MetadataConfig["dataElementsDisaggregation"][0],
         ageGroups: MetadataConfig["antigens"][0]["ageGroups"]
     ): AntigenDisaggregationCategoriesData {
         return dataElementConfig.categories.map(categoryRef => {
@@ -191,7 +190,7 @@ export class AntigensDisaggregation {
         if (!antigenConfig) throw `No configuration for antigen: ${antigenCode}`;
 
         const dataElementsProcessed = antigenConfig.dataElements.map(dataElementRef => {
-            const dataElementConfig = _(config.dataElements)
+            const dataElementConfig = _(config.dataElementsDisaggregation)
                 .keyBy("code")
                 .getOrFail(dataElementRef.code);
 
@@ -252,16 +251,14 @@ export class AntigensDisaggregation {
     }
 }
 
-export async function getDataElements(
-    db: DbD2,
+export function getDataElements(
+    config: MetadataConfig,
     disaggregationData: AntigenDisaggregationEnabled
-): Promise<DataElement[]> {
-    const dataElementCodes = _(disaggregationData)
+): DataElement[] {
+    const dataElementsByCode = _(config.dataElements).keyBy("code");
+    return _(disaggregationData)
         .flatMap(dd => dd.dataElements.map(de => de.code))
         .uniq()
+        .map(deCode => dataElementsByCode.getOrFail(deCode))
         .value();
-    const { dataElements } = await db.getMetadata<{ dataElements: DataElement[] }>({
-        dataElements: { filters: [`code:in:[${dataElementCodes.join(",")}]`] },
-    });
-    return dataElements;
 }

--- a/src/models/__tests__/config-mock.ts
+++ b/src/models/__tests__/config-mock.ts
@@ -8,13 +8,27 @@ const metadataConfig: MetadataConfig = {
     dataElementGroupCodeForAntigens: "RVC_ANTIGEN",
     categoryComboCodeForTeams: "RVC_TEAM",
     categoryCodeForTeams: "RVC_TEAM",
-    attibuteCodeForApp: "RVC_CREATED_BY_VACCINATION_APP",
+    attributeCodeForApp: "RVC_CREATED_BY_VACCINATION_APP",
     attributeCodeForDashboard: "RVC_DASHBOARD_ID",
     dataElementCodeForTotalPopulation: "RVC_TOTAL_POPULATION",
     dataElementCodeForAgeDistribution: "RVC_AGE_DISTRIBUTION",
     dataElementCodeForPopulationByAge: "RVC_POPULATION_BY_AGE",
     organisationUnitLevels: [],
     categoryCombos: [],
+    attributes: {
+        app: {
+            code: "RVC_CREATED_BY_VACCINATION_APP",
+            id: "1",
+            displayName: "Created by app",
+            valueType: "BOOLEAN",
+        },
+        dashboard: {
+            code: "RVC_DASHBOARD_ID",
+            id: "2",
+            displayName: "Dashboard ID",
+            valueType: "TEXT",
+        },
+    },
     categories: [
         {
             name: "Antigens",
@@ -98,6 +112,56 @@ const metadataConfig: MetadataConfig = {
         },
     },
     dataElements: [
+        {
+            id: "1",
+            displayName: "Vaccine doses administered",
+            code: "RVC_DOSES_ADMINISTERED",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "2",
+            displayName: "Vaccine doses used",
+            code: "RVC_USED",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "3",
+            displayName: "ADS used",
+            code: "RVC_ADS_USED",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "4",
+            displayName: "Syringes for dilution",
+            code: "RVC_SYRINGES",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "5",
+            displayName: "Needles doses used",
+            code: "RVC_NEEDLES",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "6",
+            displayName: "Safety boxes",
+            code: "RVC_SAFETY_BOXES",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "7",
+            displayName: "Accidental Exposure to Blood (AEB)",
+            code: "RVC_AEB",
+            categoryCombo: { id: "1" },
+        },
+        {
+            id: "8",
+            displayName: "Adverse Event Following Immunization",
+            code: "RVC_AEFI",
+            categoryCombo: { id: "1" },
+        },
+    ],
+    dataElementsDisaggregation: [
         {
             id: "1",
             name: "Vaccine doses administered",

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -34,7 +34,7 @@ describe("DataSets", () => {
                     fields: ["id", "attributeValues[value, attribute[code]]"],
                     paging: false,
                     filter: `attributeValues.attribute.code:eq:${
-                        metadataConfig.attibuteCodeForApp
+                        metadataConfig.attributeCodeForApp
                     }`,
                 });
 
@@ -79,12 +79,12 @@ describe("DataSets", () => {
         describe("filters datasets by attribute", () => {
             it("returns only datasets with the CREATED_BY_VACCINATION attribute set", async () => {
                 const testIds = ["id1", "id2", "id3", "id4"];
-                const code = metadataConfig.attibuteCodeForApp;
+                const attribute = metadataConfig.attributes.app;
                 const testDataSets = [
-                    { id: testIds[0], attributeValues: [{ value: "true", attribute: { code } }] },
-                    { id: testIds[1], attributeValues: [{ value: "false", attribute: { code } }] },
-                    { id: testIds[2], attributeValues: [{ value: "true", attribute: { code } }] },
-                    { id: testIds[3], attributeValues: [{ value: "false", attribute: { code } }] },
+                    { id: testIds[0], attributeValues: [{ value: "true", attribute }] },
+                    { id: testIds[1], attributeValues: [{ value: "false", attribute }] },
+                    { id: testIds[2], attributeValues: [{ value: "true", attribute }] },
+                    { id: testIds[3], attributeValues: [{ value: "false", attribute }] },
                 ];
                 const listMock = jest.fn(() =>
                     Promise.resolve({ toArray: () => testDataSets, pager: {} })

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -243,16 +243,8 @@ export default class Campaign {
         const dataSetId = generateUid();
         const metadataConfig = this.config;
         const { categoryComboCodeForTeams, categoryCodeForTeams } = metadataConfig;
-        const vaccinationAttribute = await this.db.getAttributeIdByCode(
-            metadataConfig.attibuteCodeForApp
-        );
-        const dashboardAttribute = await this.db.getAttributeIdByCode(
-            metadataConfig.attributeCodeForDashboard
-        );
-        const categoryCombos = await this.db.getCategoryCombosByCode([categoryComboCodeForTeams]);
-        const categoryCombosByCode = _(categoryCombos)
-            .keyBy("code")
-            .value();
+        const { app: attributeForApp, dashboard: dashboardAttribute } = metadataConfig.attributes;
+        const categoryCombosByCode = _.keyBy(metadataConfig.categoryCombos, "code");
         const categoryComboTeams = _(categoryCombosByCode).get(categoryComboCodeForTeams);
 
         if (!this.startDate || !this.endDate) {
@@ -271,7 +263,7 @@ export default class Campaign {
 
         const { targetPopulation } = this.data;
 
-        if (!vaccinationAttribute || !dashboardAttribute) {
+        if (!attributeForApp || !dashboardAttribute) {
             return { status: false, error: "Metadata not found: Attributes" };
         } else if (!categoryComboTeams) {
             return {
@@ -284,7 +276,7 @@ export default class Campaign {
             return { status: false, error: "There is no target population in campaign" };
         } else {
             const disaggregationData = this.getEnabledAntigensDisaggregation();
-            const dataElements = await getDataElements(this.db, disaggregationData);
+            const dataElements = getDataElements(metadataConfig, disaggregationData);
 
             const dataSetElements = dataElements.map(dataElement => ({
                 dataSet: { id: dataSetId },
@@ -324,7 +316,7 @@ export default class Campaign {
                 formType: "CUSTOM",
                 dataInputPeriods,
                 attributeValues: [
-                    { value: "true", attribute: { id: vaccinationAttribute.id } },
+                    { value: "true", attribute: { id: attributeForApp.id } },
                     { value: dashboard.id, attribute: { id: dashboardAttribute.id } },
                 ],
             };

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -292,9 +292,10 @@ export default class Campaign {
 
             const customForm = await DataSetCustomForm.build(this);
             const customFormHtml = customForm.generate();
+            const formId = generateUid();
             const dataEntryForm: DataEntryForm = {
-                id: generateUid(),
-                name: this.name,
+                id: formId,
+                name: this.name + " " + formId, // dataEntryForm.name must be unique
                 htmlCode: customFormHtml,
                 style: "NONE",
             };
@@ -319,6 +320,7 @@ export default class Campaign {
                     { value: "true", attribute: { id: attributeForApp.id } },
                     { value: dashboard.id, attribute: { id: dashboardAttribute.id } },
                 ],
+                dataEntryForm: { id: dataEntryForm.id },
             };
 
             const period = moment(this.startDate || new Date()).format("YYYYMMDD");
@@ -336,6 +338,7 @@ export default class Campaign {
                     reportTables,
                     dashboards: [dashboard],
                     dataSets: [dataSet],
+                    dataEntryForms: [dataEntryForm],
                 });
 
                 if (result.status !== "OK") {

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -40,7 +40,7 @@ export async function list(config, d2, filters, pagination) {
 }
 
 async function getByAttribute(config, d2) {
-    const appCode = config.attibuteCodeForApp;
+    const appCode = config.attributeCodeForApp;
     const filter = `attributeValues.attribute.code:eq:${appCode}`;
     const listOptions = {
         filter,
@@ -53,7 +53,8 @@ async function getByAttribute(config, d2) {
         .filter(
             ({ attributeValues }) =>
                 !!attributeValues.some(
-                    ({ attribute, value }) => attribute.code === appCode && value === "true"
+                    ({ attribute, value }) =>
+                        attribute && attribute.code === appCode && value === "true"
                 )
         )
         .map(el => el.id);

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -90,6 +90,12 @@ export interface AnalyticsResponse {
 const ref = { id: true };
 
 const metadataFields: MetadataFields = {
+    attributes: {
+        id: true,
+        code: true,
+        valueType: true,
+        displayName: true,
+    },
     categories: {
         id: true,
         displayName: true,

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -67,6 +67,9 @@ export interface CategoryCombo {
 
 export interface Attribute {
     id: string;
+    code: string;
+    valueType: "TEXT" | "BOOLEAN";
+    displayName: string;
 }
 
 export interface AttributeValue {
@@ -229,6 +232,7 @@ export interface ModelFields {
 }
 
 export type ModelName =
+    | "attributes"
     | "categories"
     | "categoryCombos"
     | "categoryOptions"

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -97,6 +97,7 @@ export interface Ref {
 
 export interface Metadata {
     dataSets?: Array<DataSet>;
+    dataEntryForms?: Array<DataEntryForm>;
     sections?: Array<Section>;
     charts?: Array<Dictionary<any>>;
     reportTables?: Array<Dictionary<any>>;
@@ -129,6 +130,7 @@ export interface DataSet {
     dataInputPeriods: DataInputPeriod[];
     attributeValues: AttributeValue[];
     formType: "DEFAULT" | "CUSTOM";
+    dataEntryForm?: Ref;
 }
 
 export interface DataEntryForm {


### PR DESCRIPTION
### :pushpin: Description

Some refactors for the campaign save process

### :memo: Implementation

- Reduce GET requests on save. Those request belong to the save process before we had a more complete config metadata Now we can remove 3 GET requests.
- Send custom form in the main POST /metadata, which is great to keep the creation in the transaction. One minor caveat: while `dataSet.name` is not required be unique, `dataEntryForm.name` is (which is a bit weird), so I append the ID to make sure it is in fact unique.

### :fire: Is there anything the reviewer should know to test it?

The save process makes 4 requests less but the exact same metadata should be created.