### PR TITLE
Remove colon from i18n messages

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-15T23:07:26.532Z\n"
-"PO-Revision-Date: 2019-04-15T23:07:26.532Z\n"
+"POT-Creation-Date: 2019-04-18T09:58:45.805Z\n"
+"PO-Revision-Date: 2019-04-18T09:58:45.805Z\n"
 
 msgid "Campaign Configuration"
 msgstr ""
@@ -176,7 +176,13 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+msgid "Disaggregation"
+msgstr ""
+
 msgid "Field cannot be blank"
+msgstr ""
+
+msgid "Campaign created"
 msgstr ""
 
 msgid "Error saving campaign"
@@ -203,6 +209,15 @@ msgstr ""
 msgid "Antigens"
 msgstr ""
 
+msgid "Population distribution (%)"
+msgstr ""
+
+msgid "Campaign Population Distribution"
+msgstr ""
+
+msgid "Missing"
+msgstr ""
+
 msgid "Help"
 msgstr ""
 
@@ -210,6 +225,12 @@ msgid "Previous"
 msgstr ""
 
 msgid "Next"
+msgstr ""
+
+msgid "Doses administered"
+msgstr ""
+
+msgid "Quality and safety indicators"
 msgstr ""
 
 msgid "Select at least one organisation unit"
@@ -231,4 +252,32 @@ msgid "You must select at least one option of the category"
 msgstr ""
 
 msgid "No target population defined"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total population value -> "
+"{{value}}"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has invalid distribution values for age "
+"ranges -> {{ageGroups}}"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total value for antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
+msgstr ""
+
+msgctxt ""
+"YEAR\n"
+"\n"
+"                    The start and end date should define the period for "
+"which you expect to enter data - i.e .the first and last day of your "
+"campaign. If you are not certain of the end date, enter a date a few weeks "
+"later than the expected date of completion (refer to your microplan). It is "
+"possible to edit the dates at any point."
+msgid ""
+"Give your campaign a name that will make it easy to recognize in an HMIS "
+"hierarchy. Suggested format is REACTIVE_VACC_LOCATION_ANTIGEN(S) _MONTH"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-15T12:15:23.972Z\n"
+"POT-Creation-Date: 2019-04-18T09:54:46.297Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -203,8 +203,14 @@ msgstr "No hay ningún dataset asociado a la campaña"
 msgid "Back"
 msgstr "Atrás"
 
+msgid "Disaggregation"
+msgstr "Desagregación"
+
 msgid "Field cannot be blank"
 msgstr "El campo no puede estar vacío"
+
+msgid "Campaign created"
+msgstr "Campaña creada"
 
 msgid "Error saving campaign"
 msgstr "Se produjo un error al guardar la campaña"
@@ -230,6 +236,15 @@ msgstr "Periodo"
 msgid "Antigens"
 msgstr "Antígenos"
 
+msgid "Population distribution (%)"
+msgstr "Distribución por edades (%)"
+
+msgid "Campaign Population Distribution"
+msgstr "Distribución de población en campaña"
+
+msgid "Missing"
+msgstr "Vacío"
+
 msgid "Help"
 msgstr "Ayuda"
 
@@ -238,6 +253,12 @@ msgstr "Anterior"
 
 msgid "Next"
 msgstr "Siguiente"
+
+msgid "Doses administered"
+msgstr "Dosis administradas"
+
+msgid "Quality and safety indicators"
+msgstr "Indicadores de calidad y seguridad"
 
 msgid "Select at least one organisation unit"
 msgstr "Seleccione al menos una unidad organizativa"
@@ -260,3 +281,39 @@ msgstr "Debes seleccionar al menos una opción de la categoría"
 
 msgid "No target population defined"
 msgstr "Población objetivo no definida"
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total population value -> "
+"{{value}}"
+msgstr ""
+"La unidad organizativa {{organisationUnit}} tiene un valor de población "
+"inválido -> {{value}}"
+
+msgid ""
+"Org unit {{organisationUnit}} has invalid distribution values for age ranges "
+"-> {{ageGroups}}"
+msgstr ""
+"La unidad organizativa {{organisationUnit}} tiene un valor de distribución de población "
+"inválido para los rangos de edad -> {{value}}"
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total value for antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
+msgstr ""
+"La unidad organizativa {{organisationUnit}} tiene un valor total inválido para el antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
+
+msgctxt ""
+"YEAR\n"
+"\n"
+"                    The start and end date should define the period for "
+"which you expect to enter data - i.e .the first and last day of your "
+"campaign. If you are not certain of the end date, enter a date a few weeks "
+"later than the expected date of completion (refer to your microplan). It is "
+"possible to edit the dates at any point."
+msgid ""
+"Give your campaign a name that will make it easy to recognize in an HMIS "
+"hierarchy. Suggested format is REACTIVE_VACC_LOCATION_ANTIGEN(S) _MONTH"
+msgstr ""
+"Dé a la campaña un nombre que sea fácil de reconocer en la jerarquía "
+"HMIS. El formato sugerido es REACTIVE_VACC_LOCALIZACION_ANTIGENO(S) _MES"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-15T12:15:23.972Z\n"
+"POT-Creation-Date: 2019-04-18T09:54:46.297Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -177,7 +177,13 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+msgid "Disaggregation"
+msgstr ""
+
 msgid "Field cannot be blank"
+msgstr ""
+
+msgid "Campaign created"
 msgstr ""
 
 msgid "Error saving campaign"
@@ -204,6 +210,15 @@ msgstr ""
 msgid "Antigens"
 msgstr ""
 
+msgid "Population distribution (%)"
+msgstr ""
+
+msgid "Campaign Population Distribution"
+msgstr ""
+
+msgid "Missing"
+msgstr ""
+
 msgid "Help"
 msgstr ""
 
@@ -211,6 +226,12 @@ msgid "Previous"
 msgstr ""
 
 msgid "Next"
+msgstr ""
+
+msgid "Doses administered"
+msgstr ""
+
+msgid "Quality and safety indicators"
 msgstr ""
 
 msgid "Select at least one organisation unit"
@@ -232,4 +253,32 @@ msgid "You must select at least one option of the category"
 msgstr ""
 
 msgid "No target population defined"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total population value -> "
+"{{value}}"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has invalid distribution values for age ranges "
+"-> {{ageGroups}}"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total value for antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
+msgstr ""
+
+msgctxt ""
+"YEAR\n"
+"\n"
+"                    The start and end date should define the period for "
+"which you expect to enter data - i.e .the first and last day of your "
+"campaign. If you are not certain of the end date, enter a date a few weeks "
+"later than the expected date of completion (refer to your microplan). It is "
+"possible to edit the dates at any point."
+msgid ""
+"Give your campaign a name that will make it easy to recognize in an HMIS "
+"hierarchy. Suggested format is REACTIVE_VACC_LOCATION_ANTIGEN(S) _MONTH"
 msgstr ""

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -62,7 +62,7 @@ class CampaignWizard extends React.Component {
                     `Name your campaign and choose dates for which data entry will be enabled`
                 ),
                 help: i18n.t(
-                    `Give your campaign a name that will make it easy to recognize in an HMIS hierarchy. Suggested format: REACTIVE_VACC_LOCATION_ANTIGEN(S) _MONTH_YEAR\n
+                    `Give your campaign a name that will make it easy to recognize in an HMIS hierarchy. Suggested format is REACTIVE_VACC_LOCATION_ANTIGEN(S) _MONTH_YEAR\n
                     The start and end date should define the period for which you expect to enter data - i.e .the first and last day of your campaign. If you are not certain of the end date, enter a date a few weeks later than the expected date of completion (refer to your microplan). It is possible to edit the dates at any point.`
                 ),
             },

--- a/src/components/steps/save/SaveStep.jsx
+++ b/src/components/steps/save/SaveStep.jsx
@@ -52,9 +52,7 @@ class SaveStep extends React.Component {
         this.setState({ isSaving: false });
 
         if (saveResponse.status) {
-            this.props.snackbar.success(
-                i18n.t("Campaign created: {{name}}", { name: campaign.name })
-            );
+            this.props.snackbar.success(`${i18n.t("Campaign created")} ${campaign.name}`);
             this.props.history.push("/campaign-configuration");
         } else {
             this.setState({ errorMessage: saveResponse.error });

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -18,19 +18,19 @@ const translations = {
     no_target_population_defined: () => i18n.t("No target population defined"),
     total_population_invalid: namespace =>
         i18n.t(
-            "Org unit {{organisationUnit}} has an invalid total population value: {{value}}",
+            "Org unit {{organisationUnit}} has an invalid total population value -> {{value}}",
             namespace
         ),
 
     age_groups_population_invalid: namespace =>
         i18n.t(
-            "Org unit {{organisationUnit}} has invalid distribution values for age ranges: {{ageGroups}}",
+            "Org unit {{organisationUnit}} has invalid distribution values for age ranges -> {{ageGroups}}",
             namespace
         ),
 
     age_groups_population_for_antigen_invalid: namespace =>
         i18n.t(
-            "Org unit {{organisationUnit}} has an invalid total value for antigen {{antigen}} ({{ageGroups}}): {{- value}}",
+            "Org unit {{organisationUnit}} has an invalid total value for antigen {{antigen}} ({{ageGroups}}) -> {{- value}}",
             namespace
         ),
 };


### PR DESCRIPTION
### :pushpin: References

While working on #81, I noticed that some i18n.t(...) strings were not being added to i18n/en.pot. 

The problem was that i18next-scanner uses by default the parsing rule `i18n.t("namespace: msg")`, so we cannot effectively use `:` within an i18n string, as there is no escaping mechanism. See https://github.com/i18next/i18next-scanner

### :memo: Implementation

- I've removed the colon char (`:`) from all translations.