### PR TITLE
Include check for teams on organisation unit validation

### DIFF
--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -29,7 +29,7 @@ describe("Campaign configuration - Create", () => {
         cy.contains("Next").click();
 
         // General Info step
-
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.contains("Next").click();
         cy.contains("Field name cannot be blank");
 
@@ -43,7 +43,7 @@ describe("Campaign configuration - Create", () => {
         cy.contains("Next").click();
 
         // Antigens selections
-
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.contains("Next").click();
         cy.contains("Select at least one antigen");
 
@@ -57,10 +57,10 @@ describe("Campaign configuration - Create", () => {
         cy.contains("Measles");
         cy.contains("Cholera");
 
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.contains("Next").click();
 
         // Target population
-
         cy.contains("Cholera Intervention Addis 2016");
 
         cy.get("[test-total-population=0] [aria-label=Edit]").click();
@@ -80,6 +80,7 @@ describe("Campaign configuration - Create", () => {
 
         // Save step
 
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.get("[data-test-current=true]").contains("Save");
 
         cy.contains("Name");
@@ -104,6 +105,7 @@ describe("Campaign configuration - Create", () => {
             .click();
 
         cy.wait("@metadataRequest");
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.contains("Campaign created: Test vaccination campaign");
     });
 });

--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -29,7 +29,7 @@ describe("Campaign configuration - Create", () => {
         cy.contains("Next").click();
 
         // General Info step
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        waitForStepChange("General info");
         cy.contains("Next").click();
         cy.contains("Field name cannot be blank");
 
@@ -43,7 +43,7 @@ describe("Campaign configuration - Create", () => {
         cy.contains("Next").click();
 
         // Antigens selections
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        waitForStepChange("Antigen selection");
         cy.contains("Next").click();
         cy.contains("Select at least one antigen");
 
@@ -54,13 +54,14 @@ describe("Campaign configuration - Create", () => {
 
         // Disaggregation
 
+        waitForStepChange("Configure Indicators");
         cy.contains("Measles");
         cy.contains("Cholera");
 
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.contains("Next").click();
 
         // Target population
+        waitForStepChange("Target Population");
         cy.contains("Cholera Intervention Addis 2016");
 
         cy.get("[test-total-population=0] [aria-label=Edit]").click();
@@ -80,7 +81,7 @@ describe("Campaign configuration - Create", () => {
 
         // Save step
 
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        waitForStepChange("Save");
         cy.get("[data-test-current=true]").contains("Save");
 
         cy.contains("Name");
@@ -145,4 +146,8 @@ function selectAntigen(label) {
     cy.get("[data-multi-selector] > div > div > div:nth-child(2)")
         .contains("→")
         .click();
+}
+
+function waitForStepChange(stepName) {
+    cy.contains(stepName).should("have.class", "current-step");
 }

--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -127,6 +127,9 @@ function selectOrgUnit(label) {
     cy.contains(label)
         .prev()
         .click();
+    cy.contains(label)
+        .should("have.css", "color")
+        .and("not.equal", "rgba(0, 0, 0, 0.87)");
 }
 
 function clickDay(dayOfMonth) {

--- a/cypress/integration/landing-page.spec.js
+++ b/cypress/integration/landing-page.spec.js
@@ -7,6 +7,7 @@ context("Landing page", () => {
     });
 
     beforeEach(() => {
+        cy.login("admin");
         cy.visit("/");
     });
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-15T23:07:26.532Z\n"
-"PO-Revision-Date: 2019-04-15T23:07:26.532Z\n"
+"POT-Creation-Date: 2019-04-24T10:05:50.426Z\n"
+"PO-Revision-Date: 2019-04-24T10:05:50.426Z\n"
 
 msgid "Campaign Configuration"
 msgstr ""
@@ -218,6 +218,9 @@ msgstr ""
 msgid "Only organisation units of level {{levels}} can be selected"
 msgstr ""
 
+msgid "Organisation Units {{orgUnits}} -> no associated teams"
+msgstr ""
+
 msgid "Field {{field}} cannot be blank"
 msgstr ""
 
@@ -231,4 +234,14 @@ msgid "You must select at least one option of the category"
 msgstr ""
 
 msgid "No target population defined"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has invalid distribution values for age "
+"ranges -> {{ageGroups}}"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total value for antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-04-24T10:05:50.426Z\n"
-"PO-Revision-Date: 2019-04-24T10:05:50.426Z\n"
+"POT-Creation-Date: 2019-04-29T11:56:24.555Z\n"
+"PO-Revision-Date: 2019-04-29T11:56:24.555Z\n"
 
 msgid "Campaign Configuration"
 msgstr ""
@@ -237,6 +237,9 @@ msgid "Select at least one organisation unit"
 msgstr ""
 
 msgid "Only organisation units of level {{levels}} can be selected"
+msgstr ""
+
+msgid "Organisation Units {{orgUnits}} -> no associated teams"
 msgstr ""
 
 msgid "Field {{field}} cannot be blank"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-15T12:15:23.972Z\n"
+"POT-Creation-Date: 2019-04-24T10:05:50.426Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -246,6 +246,9 @@ msgid "Only organisation units of level {{levels}} can be selected"
 msgstr ""
 "Puedes seleccionar únicamente unidades organizativas de nivel {{levels}}"
 
+msgid "Organisation Units {{orgUnits}} -> no associated teams"
+msgstr "Unidades organizativas {{orgUnits}} -> sin equipo asociado"
+
 msgid "Field {{field}} cannot be blank"
 msgstr "El campo {{field}} no puede estar vacío"
 
@@ -260,3 +263,15 @@ msgstr "Debes seleccionar al menos una opción de la categoría"
 
 msgid "No target population defined"
 msgstr "Población objetivo no definida"
+
+msgid ""
+"Org unit {{organisationUnit}} has invalid distribution values for age ranges "
+"-> {{ageGroups}}"
+msgstr "Unidad organizativa {{organisationUnit}} tiene una distribución de rangos de edad invalida"
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total value for antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
+msgstr ""
+"Unidad organizativa {{organisationUnit}} tiene un valor total invalido para el antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-24T10:05:50.426Z\n"
+"POT-Creation-Date: 2019-04-29T11:55:35.065Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -238,6 +238,9 @@ msgid "Select at least one organisation unit"
 msgstr ""
 
 msgid "Only organisation units of level {{levels}} can be selected"
+msgstr ""
+
+msgid "Organisation Units {{orgUnits}} -> no associated teams"
 msgstr ""
 
 msgid "Field {{field}} cannot be blank"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-04-15T12:15:23.972Z\n"
+"POT-Creation-Date: 2019-04-24T10:05:50.426Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -219,6 +219,9 @@ msgstr ""
 msgid "Only organisation units of level {{levels}} can be selected"
 msgstr ""
 
+msgid "Organisation Units {{orgUnits}} -> no associated teams"
+msgstr ""
+
 msgid "Field {{field}} cannot be blank"
 msgstr ""
 
@@ -232,4 +235,14 @@ msgid "You must select at least one option of the category"
 msgstr ""
 
 msgid "No target population defined"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has invalid distribution values for age ranges "
+"-> {{ageGroups}}"
+msgstr ""
+
+msgid ""
+"Org unit {{organisationUnit}} has an invalid total value for antigen "
+"{{antigen}} ({{ageGroups}}) -> {{- value}}"
 msgstr ""

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -46,6 +46,7 @@ class CampaignWizard extends React.Component {
                 label: i18n.t("Organisation Units"),
                 component: OrganisationUnitsStep,
                 validationKeys: ["organisationUnits"],
+                validationKeysLive: ["organisationUnits"],
                 description: i18n.t(
                     `Select the health facilities or health area where the campaign will be implemented`
                 ),
@@ -123,11 +124,10 @@ dataset and all the metadata associated with this vaccination campaign.`),
         this.setState({ dialogOpen: false });
     };
 
-    onChange = memoize(step => campaign => {
-        const errors = getValidationMessages(campaign, step.validationKeysLive || []);
-        if (_(errors).isEmpty()) {
-            this.setState({ campaign });
-        } else {
+    onChange = memoize(step => async campaign => {
+        const errors = await getValidationMessages(campaign, step.validationKeysLive || []);
+        this.setState({ campaign });
+        if (!_(errors).isEmpty()) {
             this.props.snackbar.error(errors.join("\n"));
         }
     });

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -132,8 +132,8 @@ dataset and all the metadata associated with this vaccination campaign.`),
         }
     });
 
-    onStepChangeRequest = currentStep => {
-        return getValidationMessages(this.state.campaign, currentStep.validationKeys);
+    onStepChangeRequest = async currentStep => {
+        return await getValidationMessages(this.state.campaign, currentStep.validationKeys);
     };
 
     render() {

--- a/src/components/wizard/Wizard.jsx
+++ b/src/components/wizard/Wizard.jsx
@@ -196,6 +196,7 @@ class Wizard extends React.Component {
                                 data-test-current={currentStep === step}
                                 onClick={this.onStepClicked(step.key)}
                                 classes={{ root: classes.stepButton }}
+                                className={currentStep === step ? "current-step" : ""}
                             >
                                 {step.label}
                             </StepButton>

--- a/src/components/wizard/Wizard.jsx
+++ b/src/components/wizard/Wizard.jsx
@@ -87,14 +87,13 @@ class Wizard extends React.Component {
         return { prevStepKey, nextStepKey };
     };
 
-    nextStep = () => {
+    nextStep = async () => {
         const { currentStepKey } = this.state;
         const stepsByKey = _.keyBy(this.props.steps, "key");
         const currentStep = stepsByKey[currentStepKey];
         const { nextStepKey } = this.getAdjacentSteps();
         const nextStep = stepsByKey[nextStepKey];
-        const errorMessages = this.props.onStepChangeRequest(currentStep, nextStep);
-
+        const errorMessages = await this.props.onStepChangeRequest(currentStep, nextStep);
         if (_(errorMessages).isEmpty()) {
             this.setStep(nextStepKey);
         } else {

--- a/src/models/__tests__/campaign.spec.ts
+++ b/src/models/__tests__/campaign.spec.ts
@@ -10,8 +10,8 @@ const campaign = Campaign.create(metadataConfig, db);
 
 describe("Campaign", () => {
     describe("Validations", () => {
-        it("requires a name", () => {
-            const messages = campaign.validate();
+        it("requires a name", async () => {
+            const messages = await campaign.validate();
             expect(messages).toEqual(
                 expect.objectContaining({
                     name: [
@@ -24,8 +24,8 @@ describe("Campaign", () => {
             );
         });
 
-        it("requires at least one orgunit", () => {
-            const messages = campaign.validate();
+        it("requires at least one orgunit", async () => {
+            const messages = await campaign.validate();
             expect(messages).toEqual(
                 expect.objectContaining({
                     organisationUnits: [{ key: "no_organisation_units_selected" }],
@@ -33,7 +33,7 @@ describe("Campaign", () => {
             );
         });
 
-        it("requires at least one orgunit of level 5", () => {
+        it("requires at least one orgunit of level 5", async () => {
             const ids = [
                 "zOyMxdCLXBM",
                 "G7g4TvbjFlX",
@@ -48,7 +48,7 @@ describe("Campaign", () => {
             ];
             _(1)
                 .range(10)
-                .forEach(level => {
+                .forEach(async level => {
                     const path =
                         "/" +
                         _(ids)
@@ -63,7 +63,7 @@ describe("Campaign", () => {
                             path: path,
                         },
                     ]);
-                    const messages = campaignWithOrgUnit.validate();
+                    const messages = await campaignWithOrgUnit.validate();
 
                     if (level == 5) {
                         expect(messages).toEqual(

--- a/src/models/__tests__/campaign.spec.ts
+++ b/src/models/__tests__/campaign.spec.ts
@@ -4,10 +4,11 @@ import { getD2Stub } from "../../utils/testing";
 import _ from "lodash";
 import metadataConfig from "./config-mock";
 
-const d2 = getD2Stub();
+const metadataStub = jest.fn(() => Promise.resolve({ categoryOptions: [], organisationUnits: [] }));
+
+const d2 = getD2Stub({ Api: { getApi: () => ({ get: metadataStub }) } });
 const db = new DbD2(d2);
 const campaign = Campaign.create(metadataConfig, db);
-
 describe("Campaign", () => {
     describe("Validations", () => {
         it("requires a name", async () => {

--- a/src/models/__tests__/campaign.spec.ts
+++ b/src/models/__tests__/campaign.spec.ts
@@ -69,7 +69,12 @@ describe("Campaign", () => {
                     if (level == 5) {
                         expect(messages).toEqual(
                             expect.objectContaining({
-                                organisationUnits: [],
+                                organisationUnits: [
+                                    {
+                                        key: "no_valid_teams_for_organisation_units",
+                                        namespace: { orgUnits: "" },
+                                    },
+                                ],
                             })
                         );
                     } else {
@@ -79,6 +84,10 @@ describe("Campaign", () => {
                                     {
                                         key: "organisation_units_only_of_levels",
                                         namespace: { levels: "5" },
+                                    },
+                                    {
+                                        key: "no_valid_teams_for_organisation_units",
+                                        namespace: { orgUnits: "" },
                                     },
                                 ],
                             })

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -109,14 +109,14 @@ export default class Campaign {
         );
         const levels = this.selectableLevels.join("/");
 
-        const haveTeams = await this.db.validateTeamsForOrganisationUnits(
+        const orgUnitsWithTeamsInfo = await this.db.validateTeamsForOrganisationUnits(
             organisationUnits,
             this.config.categoryCodeForTeams
         );
 
-        const noTeams = _(haveTeams)
-            .filter(o => !o.hasTeams)
-            .map("displayName")
+        const orgUnitsWithoutTeams = _(orgUnitsWithTeamsInfo)
+            .filter(ou => !ou.hasTeams)
+            .map(ou => ou.displayName)
             .value();
 
         const errorsList = [
@@ -124,9 +124,9 @@ export default class Campaign {
                 ? getError("organisation_units_only_of_levels", { levels })
                 : [],
             _(organisationUnits).isEmpty() ? getError("no_organisation_units_selected") : [],
-            !_.isEmpty(noTeams)
+            !_.isEmpty(orgUnitsWithoutTeams)
                 ? getError("no_valid_teams_for_organisation_units", {
-                      orgUnits: noTeams.join(", "),
+                      orgUnits: orgUnitsWithoutTeams.join(", "),
                   })
                 : [],
         ];

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -109,7 +109,10 @@ export default class Campaign {
         );
         const levels = this.selectableLevels.join("/");
 
-        const haveTeams = await this.db.validateTeamsForOrganisationUnits(organisationUnits);
+        const haveTeams = await this.db.validateTeamsForOrganisationUnits(
+            organisationUnits,
+            this.config.categoryCodeForTeams
+        );
 
         const noTeams = _(haveTeams)
             .filter(o => !o.hasTeams)

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -212,28 +212,28 @@ export default class DbD2 {
 
         const { categoryOptions, organisationUnits: orgUnitNamesArray } = response as {
             categoryOptions?: CategoryOptionsCustom[];
-            organisationUnits: OrganisationUnitWithName[];
+            organisationUnits?: OrganisationUnitWithName[];
         };
 
         const hasTeams = (path: string) => {
             return (categoryOptions || []).some(
-                co =>
-                    _(co.categories)
+                categoryOption =>
+                    _(categoryOption.categories)
                         .map("code")
                         .includes(categoryCodeForTeams) &&
-                    co.organisationUnits.some(ou => path.includes(ou.id))
+                    categoryOption.organisationUnits.some(ou => path.includes(ou.id))
             );
         };
 
-        const orgUnitNames = _(orgUnitNamesArray)
-            .map((o: OrganisationUnitWithName) => [o.id, o.displayName])
+        const orgUnitNames: _.Dictionary<string> = _(orgUnitNamesArray)
+            .map(o => [o.id, o.displayName])
             .fromPairs()
             .value();
 
-        return _(organisationUnits)
+        return _(organisationUnits || [])
             .map(ou => ({
                 id: ou.id,
-                displayName: orgUnitNames[ou.id],
+                displayName: _(orgUnitNames).getOrFail(ou.id),
                 hasTeams: hasTeams(ou.path),
             }))
             .value();

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -256,3 +256,38 @@ export interface DashboardData {
 }
 
 export type MetadataGetParams = { [key in ModelName]?: MetadataGetModelParams | undefined };
+
+export interface CategoryCustom {
+    id: string;
+    categoryOptions: CategoryOption[];
+}
+
+export interface DataElementItemCustom {
+    id: string;
+    code: string;
+}
+
+export interface CategoryOptionsCustom {
+    id: string;
+    categories: Array<{ id: string; code: string }>;
+    organisationUnits: Ref[];
+}
+
+export interface OrganisationUnitWithName {
+    id: string;
+    displayName: string;
+    path: string;
+}
+
+export interface DashboardMetadataRequest {
+    categories: CategoryCustom[];
+    dataElements: DataElementItemCustom[];
+    indicators: DataElementItemCustom[];
+    categoryOptions: CategoryOptionsCustom[];
+    organisationUnits: OrganisationUnitWithName[];
+}
+
+export interface CategoryOptionForTeams {
+    id: string;
+    organisationUnits: Ref[];
+}

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -286,8 +286,3 @@ export interface DashboardMetadataRequest {
     categoryOptions: CategoryOptionsCustom[];
     organisationUnits: OrganisationUnitWithName[];
 }
-
-export interface CategoryOptionForTeams {
-    id: string;
-    organisationUnits: Ref[];
-}

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -39,8 +39,10 @@ const mocks = {
 
 function deepMerge(object, source) {
     return _.mergeWith(object, source, function(objValue, srcValue) {
-        if (_.isObject(objValue) && srcValue) {
+        if (_.isObject(objValue) && !_.isFunction(objValue) && srcValue) {
             return deepMerge(objValue, srcValue);
+        } else if (_.isFunction(objValue) && _.isFunction(srcValue)) {
+            return srcValue;
         }
     });
 }

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -6,6 +6,9 @@ const translations = {
     organisation_units_only_of_levels: namespace =>
         i18n.t("Only organisation units of level {{levels}} can be selected", namespace),
 
+    no_valid_teams_for_organisation_units: namespace =>
+        i18n.t("Organisation Units: {{orgUnits}} have no associated teams", namespace),
+
     cannot_be_blank: namespace => i18n.t("Field {{field}} cannot be blank", namespace),
     cannot_be_blank_if_other_set: namespace =>
         i18n.t("Field {{field}} cannot be blank if field {{other}} is set", namespace),
@@ -35,10 +38,10 @@ const translations = {
         ),
 };
 
-export function getValidationMessages(campaign, validationKeys) {
+export async function getValidationMessages(campaign, validationKeys) {
     if (_(validationKeys).isEmpty()) return [];
 
-    const validationObj = campaign.validate();
+    const validationObj = await campaign.validate();
 
     return _(validationObj)
         .at(validationKeys)

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -7,7 +7,7 @@ const translations = {
         i18n.t("Only organisation units of level {{levels}} can be selected", namespace),
 
     no_valid_teams_for_organisation_units: namespace =>
-        i18n.t("Organisation Units: {{orgUnits}} have no associated teams", namespace),
+        i18n.t("Organisation Units {{orgUnits}}: no associated teams", namespace),
 
     cannot_be_blank: namespace => i18n.t("Field {{field}} cannot be blank", namespace),
     cannot_be_blank_if_other_set: namespace =>

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -7,7 +7,7 @@ const translations = {
         i18n.t("Only organisation units of level {{levels}} can be selected", namespace),
 
     no_valid_teams_for_organisation_units: namespace =>
-        i18n.t("Organisation Units {{orgUnits}}: no associated teams", namespace),
+        i18n.t("Organisation Units {{orgUnits}} -> no associated teams", namespace),
 
     cannot_be_blank: namespace => i18n.t("Field {{field}} cannot be blank", namespace),
     cannot_be_blank_if_other_set: namespace =>
@@ -27,13 +27,13 @@ const translations = {
 
     age_groups_population_invalid: namespace =>
         i18n.t(
-            "Org unit {{organisationUnit}} has invalid distribution values for age ranges: {{ageGroups}}",
+            "Org unit {{organisationUnit}} has invalid distribution values for age ranges -> {{ageGroups}}",
             namespace
         ),
 
     age_groups_population_for_antigen_invalid: namespace =>
         i18n.t(
-            "Org unit {{organisationUnit}} has an invalid total value for antigen {{antigen}} ({{ageGroups}}): {{- value}}",
+            "Org unit {{organisationUnit}} has an invalid total value for antigen {{antigen}} ({{ageGroups}}) -> {{- value}}",
             namespace
         ),
 };


### PR DESCRIPTION
### :pushpin: References

* **Issue:** #82 

### :memo: Implementation
Checks at the end of the Organisation Unit wizard step for associated teams. If some chosen OU does not have any associated teams a snackbar message is displayed and progression blocked.


### :art: Screenshots
![image](https://user-images.githubusercontent.com/15323369/56357190-48493480-61db-11e9-82ab-9af162721025.png)


### :fire: Is there anything the reviewer should know to test it?
OC - TEMP organisations units don't have teams associated.
