### PR TITLE
Fix Cypress campaign list test

### DIFF
--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -1,4 +1,3 @@
-/* Disable: TODO: setup /more robust
 describe("Campaign configuration - List page", () => {
     beforeEach(() => {
         cy.login("admin");
@@ -11,23 +10,17 @@ describe("Campaign configuration - List page", () => {
     });
 
     it("shows list of user campaigns", () => {
-        cy.get(".data-table__rows__row").should("have.length", 20);
-
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
-            "have.text",
-            "Cholera Outbreak - Daily "
-        );
+        cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span").should("not.be.empty");
     });
 
     it("opens details window when mouse clicked", () => {
-        cy.contains("Cholera Outbreak - Daily ").click();
-
-        cy.contains("Short name");
-        cy.contains("v6hCzYgjqq3");
+        cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span").click();
+        cy.contains("API link");
+        cy.contains("Id");
     });
 
     it("opens context window when right button mouse is clicked", () => {
-        cy.contains("Cholera Outbreak - Daily ")
+        cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span")
             .first()
             .trigger("contextmenu");
 
@@ -45,19 +38,31 @@ describe("Campaign configuration - List page", () => {
     it("shows list of user dataset sorted alphabetically", () => {
         cy.get("[data-test='only-my-campaigns']").uncheck();
 
-        cy.get(".data-table__rows__row").should("have.length", 20);
-
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
-            "have.text",
-            "Cholera Outbreak - Daily "
-        );
-
-        cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").should(
-            "not.have.text",
-            "Community-based Activities - Weekly"
-        );
+        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
+            cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
+                assert.isTrue(text1.text() < text2.text());
+            });
+        });
     });
 
+    it("shows list of user dataset sorted alphabetically desc", () => {
+        cy.get("[data-test='search']").clear();
+        cy.server()
+            .route("GET", "/api/dataSets*")
+            .as("getDataSets");
+
+        cy.contains("Name").click();
+
+        cy.wait("@getDataSets");
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
+            cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
+                console.log({ 1: text1.text(), 2: text2.text() });
+                assert.isTrue(text1.text() > text2.text());
+            });
+        });
+    });
+    /*
     it("can filter datasets by name (case insensitive)", () => {
         cy.get("[data-test='only-my-campaigns']").uncheck();
 
@@ -80,21 +85,5 @@ describe("Campaign configuration - List page", () => {
             "Meningitis Outbreak - Weekly"
         );
     });
-
-    it("shows list of user dataset sorted alphabetically desc", () => {
-        cy.get("[data-test='search']").clear();
-        cy.server()
-            .route("GET", "/api/dataSets*")
-            .as("getDataSets");
-        cy.contains("Name").click();
-        cy.wait("@getDataSets");
-
-        cy.get(".data-table__rows__row").should("have.length", 20);
-
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
-            "have.text",
-            "Vaccination Women - Weekly"
-        );
-    });
+    */
 });
-*/


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #101 

### :memo: Implementation
Removed all text references. We should decide if it's worth it mocking the `list` method to stub responses. Will make tests more robust but it also defeats the purpose of end-to-end testing so I leave it up for discussion

Missing: 
- [ ] Search box filtering (related to stubbing list method to return fixtures) 