### PR TITLE
Create and delete dataSets for cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ src/locales/
 # cypress
 cypress/screenshots/
 cypress/videos/
-cypress/fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
 - 8.10.0
+addons:
+  apt:
+    packages:
+      - libgconf-2-4
 cache:
   directories:
   - "$HOME/.cache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install:
     - yarn cy:verify
     - yarn build
 script:
-    - PORT=8081 REACT_APP_DHIS2_BASE_URL=http://dev2.eyeseetea.com:8082 yarn start &
-    - yarn run wait-on http://localhost:8081 && sleep 10s
-    - REACT_APP_CYPRESS=true CYPRESS_EXTERNAL_API=http://dev2.eyeseetea.com:8082 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run
+    - PORT=8081 REACT_APP_CYPRESS=true REACT_APP_DHIS2_BASE_URL=http://dev2.eyeseetea.com:8082 yarn start &
+    - yarn run wait-on http-get://localhost:8081
+    - CYPRESS_EXTERNAL_API=http://dev2.eyeseetea.com:8082 CYPRESS_ROOT_URL=http://localhost:8081 yarn cy:e2e:run
     - kill $(jobs -p) || true
 notifications:
   slack:

--- a/cypress/fixtures/datasets.json
+++ b/cypress/fixtures/datasets.json
@@ -1,5 +1,5 @@
 {
-    "0": {
+    "cypressA": {
         "id": "kT5ewdJqZDT",
         "name": "cypressA",
         "description": "",
@@ -128,7 +128,7 @@
         ],
         "organisationUnits": [{ "id": "qpJEeiIfW42" }]
     },
-    "1": {
+    "cypressB": {
         "id": "kT5ewdJqPLT",
         "name": "cypressB",
         "description": "",
@@ -257,7 +257,7 @@
         ],
         "organisationUnits": [{ "id": "qpJEeiIfW42" }]
     },
-    "2": {
+    "cypressC": {
         "id": "kT5ewdJqRTY",
         "name": "cypressC",
         "description": "",

--- a/cypress/fixtures/datasets.json
+++ b/cypress/fixtures/datasets.json
@@ -1,7 +1,7 @@
 {
     "0": {
         "id": "kT5ewdJqZDT",
-        "name": "AcypressTestDataSet",
+        "name": "cypressA",
         "description": "",
         "publicAccess": "r-r-----",
         "periodType": "Daily",
@@ -130,7 +130,136 @@
     },
     "1": {
         "id": "kT5ewdJqPLT",
-        "name": "BcypressTestDataSet",
+        "name": "cypressB",
+        "description": "",
+        "publicAccess": "r-r-----",
+        "periodType": "Daily",
+        "categoryCombo": { "id": "SS8lww0UED6" },
+        "dataElementDecoration": true,
+        "renderAsTabs": true,
+        "dataSetElements": [
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "ywKG3QmCbDi"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "ycy4WvaTCtm"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "q0MMyiUi0Pl"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "O0UJyI8lwvU"
+                },
+                "dataElement": {
+                    "id": "mkgnDxyksQS"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "CCqBBZmfsTs"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "Sm65ETbrxKc"
+                },
+                "dataElement": {
+                    "id": "OY40ChLj0YE"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "WCQHqR2RBIX"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "OQOgTET6NwY"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            }
+        ],
+        "openFuturePeriods": 1,
+        "timelyDays": 0,
+        "expiryDays": 0,
+        "formType": "CUSTOM",
+        "dataInputPeriods": [
+            {
+                "closingDate": "2019-04-01T21:59:59.999",
+                "openingDate": "2019-03-14T23:00:00.000",
+                "period": {
+                    "id": "20190326"
+                }
+            },
+            {
+                "closingDate": "2019-04-01T21:59:59.999",
+                "openingDate": "2019-03-14T23:00:00.000",
+                "period": {
+                    "id": "20190329"
+                }
+            }
+        ],
+        "attributeValues": [
+            {
+                "value": "true",
+                "attribute": {
+                    "id": "Wk6tLwX96Md"
+                }
+            }
+        ],
+        "organisationUnits": [{ "id": "qpJEeiIfW42" }]
+    },
+    "2": {
+        "id": "kT5ewdJqRTY",
+        "name": "cypressC",
         "description": "",
         "publicAccess": "r-r-----",
         "periodType": "Daily",

--- a/cypress/fixtures/datasets.json
+++ b/cypress/fixtures/datasets.json
@@ -1,0 +1,260 @@
+{
+    "0": {
+        "id": "kT5ewdJqZDT",
+        "name": "AcypressTestDataSet",
+        "description": "",
+        "publicAccess": "r-r-----",
+        "periodType": "Daily",
+        "categoryCombo": { "id": "SS8lww0UED6" },
+        "dataElementDecoration": true,
+        "renderAsTabs": true,
+        "dataSetElements": [
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "ywKG3QmCbDi"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "ycy4WvaTCtm"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "q0MMyiUi0Pl"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "O0UJyI8lwvU"
+                },
+                "dataElement": {
+                    "id": "mkgnDxyksQS"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "CCqBBZmfsTs"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "Sm65ETbrxKc"
+                },
+                "dataElement": {
+                    "id": "OY40ChLj0YE"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "WCQHqR2RBIX"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "OQOgTET6NwY"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            }
+        ],
+        "openFuturePeriods": 1,
+        "timelyDays": 0,
+        "expiryDays": 0,
+        "formType": "CUSTOM",
+        "dataInputPeriods": [
+            {
+                "closingDate": "2019-04-01T21:59:59.999",
+                "openingDate": "2019-03-14T23:00:00.000",
+                "period": {
+                    "id": "20190326"
+                }
+            },
+            {
+                "closingDate": "2019-04-01T21:59:59.999",
+                "openingDate": "2019-03-14T23:00:00.000",
+                "period": {
+                    "id": "20190329"
+                }
+            }
+        ],
+        "attributeValues": [
+            {
+                "value": "true",
+                "attribute": {
+                    "id": "Wk6tLwX96Md"
+                }
+            }
+        ],
+        "organisationUnits": [{ "id": "qpJEeiIfW42" }]
+    },
+    "1": {
+        "id": "kT5ewdJqPLT",
+        "name": "BcypressTestDataSet",
+        "description": "",
+        "publicAccess": "r-r-----",
+        "periodType": "Daily",
+        "categoryCombo": { "id": "SS8lww0UED6" },
+        "dataElementDecoration": true,
+        "renderAsTabs": true,
+        "dataSetElements": [
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "ywKG3QmCbDi"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "ycy4WvaTCtm"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "q0MMyiUi0Pl"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "O0UJyI8lwvU"
+                },
+                "dataElement": {
+                    "id": "mkgnDxyksQS"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "CCqBBZmfsTs"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "Sm65ETbrxKc"
+                },
+                "dataElement": {
+                    "id": "OY40ChLj0YE"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "WCQHqR2RBIX"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            },
+            {
+                "categoryCombo": {
+                    "id": "m6IIKizUedi"
+                },
+                "dataElement": {
+                    "id": "OQOgTET6NwY"
+                },
+                "dataSet": {
+                    "id": "a2345678911"
+                }
+            }
+        ],
+        "openFuturePeriods": 1,
+        "timelyDays": 0,
+        "expiryDays": 0,
+        "formType": "CUSTOM",
+        "dataInputPeriods": [
+            {
+                "closingDate": "2019-04-01T21:59:59.999",
+                "openingDate": "2019-03-14T23:00:00.000",
+                "period": {
+                    "id": "20190326"
+                }
+            },
+            {
+                "closingDate": "2019-04-01T21:59:59.999",
+                "openingDate": "2019-03-14T23:00:00.000",
+                "period": {
+                    "id": "20190329"
+                }
+            }
+        ],
+        "attributeValues": [
+            {
+                "value": "true",
+                "attribute": {
+                    "id": "Wk6tLwX96Md"
+                }
+            }
+        ],
+        "organisationUnits": [{ "id": "qpJEeiIfW42" }]
+    }
+}

--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -3,7 +3,7 @@ describe("Campaign configuration - List page", () => {
         cy.login("admin");
         cy.fixture("datasets.json").then(testDataSets => {
             cy.request("POST", "http://dev2.eyeseetea.com:8082/api/metadata", {
-                dataSets: [testDataSets["0"], testDataSets["1"]],
+                dataSets: [testDataSets["0"], testDataSets["1"], testDataSets["2"]],
             });
         });
     });
@@ -67,13 +67,8 @@ describe("Campaign configuration - List page", () => {
     });
 
     it("shows list of user dataset sorted alphabetically desc", () => {
-        cy.server()
-            .route("GET", "/api/dataSets*")
-            .as("getDataSets");
-        cy.wait("@getDataSets");
         cy.contains("Name").click();
-        cy.wait("@getDataSets");
-        cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
             cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
                 assert.isTrue(text1.text() > text2.text());
@@ -86,18 +81,34 @@ describe("Campaign configuration - List page", () => {
 
         cy.get("[data-test='search']")
             .clear()
-            .type("cypressTestDataSet");
+            .type("cypress");
 
-        cy.get(".data-table__rows__row").should("have.length", 2);
+        cy.get(".data-table__rows__row").should("have.length", 3);
 
         cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
             "have.text",
-            "AcypressTestDataSet"
+            "cypressA"
         );
 
         cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").should(
             "have.text",
-            "BcypressTestDataSet"
+            "cypressB"
         );
+    });
+
+    it("deletes a dataset when clicked on the Delete context action", () => {
+        cy.get("[data-test='search']")
+            .clear()
+            .type("cypressC");
+        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span")
+            .first()
+            .trigger("contextmenu");
+
+        cy.contains("Delete").click();
+        cy.contains("Yes").click();
+
+        cy.contains("Campaign(s) deleted");
     });
 });

--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -9,6 +9,7 @@ describe("Campaign configuration - List page", () => {
     });
 
     beforeEach(() => {
+        cy.login("admin");
         cy.loadPage();
         cy.contains("Campaign Configuration").click();
     });

--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -1,4 +1,3 @@
-/* Disable: TODO: setup /more robust
 describe("Campaign configuration - List page", () => {
     beforeEach(() => {
         cy.login("admin");
@@ -11,23 +10,17 @@ describe("Campaign configuration - List page", () => {
     });
 
     it("shows list of user campaigns", () => {
-        cy.get(".data-table__rows__row").should("have.length", 20);
-
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
-            "have.text",
-            "Cholera Outbreak - Daily "
-        );
+        cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span").should("not.be.empty");
     });
 
     it("opens details window when mouse clicked", () => {
-        cy.contains("Cholera Outbreak - Daily ").click();
-
-        cy.contains("Short name");
-        cy.contains("v6hCzYgjqq3");
+        cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span").click();
+        cy.contains("API link");
+        cy.contains("Id");
     });
 
     it("opens context window when right button mouse is clicked", () => {
-        cy.contains("Cholera Outbreak - Daily ")
+        cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span")
             .first()
             .trigger("contextmenu");
 
@@ -45,19 +38,31 @@ describe("Campaign configuration - List page", () => {
     it("shows list of user dataset sorted alphabetically", () => {
         cy.get("[data-test='only-my-campaigns']").uncheck();
 
-        cy.get(".data-table__rows__row").should("have.length", 20);
-
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
-            "have.text",
-            "Cholera Outbreak - Daily "
-        );
-
-        cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").should(
-            "not.have.text",
-            "Community-based Activities - Weekly"
-        );
+        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
+            cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
+                assert.isTrue(text1.text() < text2.text());
+            });
+        });
     });
 
+    it("shows list of user dataset sorted alphabetically desc", () => {
+        cy.get("[data-test='search']").clear();
+        cy.server()
+            .route("GET", "/api/dataSets*")
+            .as("getDataSets");
+
+        cy.contains("Name").click();
+
+        cy.wait("@getDataSets");
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
+            cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
+                console.log({ 1: text1.text(), 2: text2.text() });
+                assert.isTrue(text1.text() > text2.text());
+            });
+        });
+    });
+    /*
     it("can filter datasets by name (case insensitive)", () => {
         cy.get("[data-test='only-my-campaigns']").uncheck();
 
@@ -80,21 +85,5 @@ describe("Campaign configuration - List page", () => {
             "Meningitis Outbreak - Weekly"
         );
     });
-
-    it("shows list of user dataset sorted alphabetically desc", () => {
-        cy.get("[data-test='search']").clear();
-        cy.server()
-            .route("GET", "/api/dataSets*")
-            .as("getDataSets");
-        cy.contains("Name").click();
-        cy.wait("@getDataSets");
-
-        cy.get(".data-table__rows__row").should("have.length", 20);
-
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").should(
-            "have.text",
-            "Vaccination Women - Weekly"
-        );
-    });
+    */
 });
-*/

--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -1,9 +1,12 @@
+import { getApiUrl } from "../../support/utils";
+import _ from "lodash";
+
 describe("Campaign configuration - List page", () => {
     before(() => {
         cy.login("admin");
         cy.fixture("datasets.json").then(testDataSets => {
-            cy.request("POST", "http://dev2.eyeseetea.com:8082/api/metadata", {
-                dataSets: [testDataSets["0"], testDataSets["1"], testDataSets["2"]],
+            cy.request("POST", getApiUrl("/metadata"), {
+                dataSets: _.values(testDataSets),
             });
         });
     });
@@ -16,14 +19,13 @@ describe("Campaign configuration - List page", () => {
 
     after(() => {
         cy.fixture("datasets.json").then(testDataSets => {
-            cy.request(
-                "DELETE",
-                `http://dev2.eyeseetea.com:8082/api/dataSets/${testDataSets["0"].id}`
-            );
-            cy.request(
-                "DELETE",
-                `http://dev2.eyeseetea.com:8082/api/dataSets/${testDataSets["1"].id}`
-            );
+            _(testDataSets).each(dataSet => {
+                cy.request({
+                    method: "DELETE",
+                    url: getApiUrl(`/dataSets/${dataSet.id}`),
+                    failOnStatusCode: false,
+                });
+            });
         });
     });
 

--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -72,10 +72,14 @@ describe("Campaign configuration - List page", () => {
     it("shows list of user dataset sorted alphabetically desc", () => {
         cy.contains("Name").click();
         cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
-        cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
-            cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
-                assert.isTrue(text1.text() > text2.text());
-            });
+
+        cy.get(".data-table__rows > * > :nth-child(2) span").then(spans$ => {
+            const names = spans$.get().map(x => x.innerText);
+            const sortedNames = _(names)
+                .orderBy(name => name.toLowerCase())
+                .reverse()
+                .value();
+            assert.isTrue(_.isEqual(names, sortedNames));
         });
     });
 

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -1,0 +1,6 @@
+import { externalUrl } from "./network-fixtures";
+
+export function getApiUrl(path) {
+    const parts = [externalUrl, "api", path];
+    return parts.map(part => part.replace(/\/+$/, "").replace(/^\/+/, "")).join("/");
+}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #101 

### :memo: Implementation
-  A couple of datasets are created on dev2 before the tests run and are cleaned up after they finish running.
- Fixed sorting and search box filtering tests.
- Added test for Delete context action
