### PR TITLE
Add doses disaggregation to dashboard

### DIFF
--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -35,7 +35,11 @@ export default class CampaignDb {
         const { campaign } = this;
         const { db, targetPopulation, config: metadataConfig, teamsMetadata } = campaign;
         const dataSetId = campaign.id || generateUid();
-        const { categoryComboCodeForTeams, categoryCodeForTeams } = metadataConfig;
+        const {
+            categoryComboCodeForTeams,
+            categoryCodeForTeams,
+            categoryCodeForDoses,
+        } = metadataConfig;
         const { app: attributeForApp, dashboard: dashboardAttribute } = metadataConfig.attributes;
         const categoryComboIdForTeams = _(metadataConfig.categoryCombos)
             .keyBy("code")
@@ -43,6 +47,10 @@ export default class CampaignDb {
         const teamsCategoryId = _(metadataConfig.categories)
             .keyBy("code")
             .getOrFail(categoryCodeForTeams).id;
+
+        const dosesCategoryId = _(metadataConfig.categories)
+            .keyBy("code")
+            .getOrFail(categoryCodeForDoses).id;
 
         if (!campaign.startDate || !campaign.endDate) {
             return { status: false, error: "Campaign Dates not set" };
@@ -81,6 +89,7 @@ export default class CampaignDb {
             ageGroupCategoryId,
             teamsCategoyId: teamsCategoryId,
             teamIds,
+            dosesCategoryId,
         });
 
         if (!attributeForApp || !dashboardAttribute) {

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -55,7 +55,8 @@ export class Dashboard {
         categoryOptions: CategoryOption[],
         ageGroupCategoryId: string,
         teamsCategoryId: string,
-        teamIds: string[]
+        teamIds: string[],
+        dosesCategoryId: string
     ) {
         const orgUnitsId = _(organisationUnitsPathOnly).map("id");
         const dashboardItems = [dashboardItemsConfig.charts, dashboardItemsConfig.tables];
@@ -121,6 +122,11 @@ export class Dashboard {
             .fromPairs()
             .value();
 
+        const dosesByAntigen = _(antigensDisaggregation)
+            .map(d => [d.antigen.id, d.antigen.doses])
+            .fromPairs()
+            .value();
+
         const dashboardMetadata = {
             antigenCategory: antigenCategory.id,
             dataElements: {
@@ -144,6 +150,10 @@ export class Dashboard {
                     categoryId: ageGroupCategoryId,
                     elements: ageGroupsByAntigen[antigen.id],
                 }),
+                doses: (antigen: Ref) => ({
+                    categoryId: dosesCategoryId,
+                    elements: dosesByAntigen[antigen.id],
+                }),
             },
         };
 
@@ -162,6 +172,7 @@ export class Dashboard {
         ageGroupCategoryId,
         teamsCategoyId,
         teamIds,
+        dosesCategoryId,
     }: {
         dashboardId?: string;
         datasetName: string;
@@ -174,6 +185,7 @@ export class Dashboard {
         ageGroupCategoryId: string;
         teamsCategoyId: string;
         teamIds: string[];
+        dosesCategoryId: string;
     }): Promise<{ dashboard: DashboardData; charts: Array<object>; reportTables: Array<object> }> {
         const dashboardItemsMetadata = await this.getMetadataForDashboardItems(
             antigens,
@@ -182,7 +194,8 @@ export class Dashboard {
             categoryOptions,
             ageGroupCategoryId,
             teamsCategoyId,
-            teamIds
+            teamIds,
+            dosesCategoryId
         );
         const dashboardItems = this.createDashboardItems(
             datasetName,

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -17,6 +17,7 @@ export interface Antigen {
     id: string;
     name: string;
     code: string;
+    doses: { id: string; name: string }[];
 }
 
 export interface Data {

--- a/src/models/dashboard-items.js
+++ b/src/models/dashboard-items.js
@@ -8,7 +8,7 @@ export const dashboardItemsConfig = {
             elements: ["RVC_DOSES_ADMINISTERED", "RVC_DOSES_USED"],
             dataType: "DATA_ELEMENT",
             appendCode: "vTable",
-            disaggregatedBy: ["team", "ageGroup"],
+            disaggregatedBy: ["team", "ageGroup", "doses"],
         },
         qsIndicators: {
             elements: [
@@ -69,7 +69,10 @@ function getDisaggregations(itemConfigs, disaggregationMetadata, antigen) {
 
     const teams = c => (c.disaggregatedBy.includes("team") ? disaggregationMetadata.teams() : null);
 
-    return _.compact([teams(itemConfigs), ageGroups(itemConfigs)]);
+    const doses = c =>
+        c.disaggregatedBy.includes("doses") ? disaggregationMetadata.doses(antigen) : null;
+
+    return _.compact([teams(itemConfigs), ageGroups(itemConfigs), doses(itemConfigs)]);
 }
 
 function getCharts(antigen, elements, organisationUnit, itemsMetadata, disaggregationMetadata) {

--- a/src/models/dashboard-items.js
+++ b/src/models/dashboard-items.js
@@ -5,7 +5,7 @@ export const dashboardItemsConfig = {
     antigenCategoryCode: "RVC_ANTIGEN",
     tables: {
         vaccines: {
-            elements: ["RVC_DOSES_ADMINISTERED", "RVC_DOSES_USED"],
+            elements: ["RVC_DOSES_ADMINISTERED"],
             dataType: "DATA_ELEMENT",
             appendCode: "vTable",
             disaggregatedBy: ["team", "ageGroup", "doses"],


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #168

### :memo: Implementation
There are some issues with disaggregating the required tables/charts with this new dimension. 
Both coverage chart/tables: this indicator is calculated dividing `dosesAdministered` by `ageRange`, same issue arises as ageRange is not disaggregated by doses, dhis can't calculate the disaggregation so charts turn up empty. -- In discussion about how to proceed.

Removed `Vaccines doses used` from vaccines table due to disaggregations preventing from showing the data. Will probably go on a separate table with other dataElements but on a separate issue as it's still in discussion

### :art: Screenshots
<img width="998" alt="imagen" src="https://user-images.githubusercontent.com/15323369/59662924-3b7e9800-91ae-11e9-88c7-2023404e4754.png">
<img width="895" alt="imagen" src="https://user-images.githubusercontent.com/15323369/59662933-420d0f80-91ae-11e9-9eef-79e0cdbcdde2.png">



