### PR TITLE
Ignore specific bad responses on deleteMany method

### DIFF
--- a/src/models/Teams.ts
+++ b/src/models/Teams.ts
@@ -185,16 +185,27 @@ export async function getTeamsForCampaign(
         "categoryOptions:filter": `organisationUnits.id:in:[${organisationUnitIds}]`,
     });
 
-    if (_.isEmpty(categoryOptions)) return [];
-    const expression = `^Team \\d - ${campaignName}$`;
-    const matcher = new RegExp(expression);
+    return filterTeamsByNames(categoryOptions, [campaignName], teamCategoryId);
+}
 
-    const teams = categoryOptions.filter(
+export function filterTeamsByNames(
+    teams: CategoryOptionTeam[],
+    campaignNames: string[],
+    teamCategoryId: string
+): CategoryOptionTeam[] {
+    if (_.isEmpty(teams)) return [];
+
+    const matchers = campaignNames.map(name => new RegExp(`^Team \\d - ${name}$`));
+
+    const filteredTeams = teams.filter(
         (co: { categories: Array<{ id: string }>; name: string }) => {
             const categoryIds = co.categories.map(c => c.id);
-            return _.includes(categoryIds, teamCategoryId) && matcher.test(co.name);
+            return (
+                _.includes(categoryIds, teamCategoryId) &&
+                matchers.some(matcher => matcher.test(co.name))
+            );
         }
     );
 
-    return teams;
+    return filteredTeams;
 }

--- a/src/models/Teams.ts
+++ b/src/models/Teams.ts
@@ -100,10 +100,11 @@ export class Teams {
     ): CategoryOptionTeam[] {
         const teamsData: CategoryOptionTeam[] = _.range(1, teams + 1).map(i => {
             const name = `Team ${nameOffset + i} - ${campaignName}`;
+            const id = generateUid();
             const categoryOption = {
-                id: generateUid(),
+                id,
                 name,
-                shortName: name,
+                shortName: `Team ${nameOffset + i}_${id}`,
                 displayName: name,
                 publicAccess: "rw------",
                 displayShortName: name,

--- a/src/models/Teams.ts
+++ b/src/models/Teams.ts
@@ -170,7 +170,7 @@ export class Teams {
     // Teams must be deleted after all asociated dashboard and dashboard items (favorites) are deleted
     static async deleteTeams(db: DbD2, teams: CategoryOptionTeam[]) {
         const toDelete = teams.map(t => ({ model: "categoryOptions", id: t.id }));
-        return await db.deleteMany(toDelete);
+        return await db.deleteMany(toDelete, ["categoryOptions"]);
     }
 }
 

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -4,6 +4,7 @@ import metadataConfig from "./config-mock";
 
 const expectedFields = [
     "id",
+    "name",
     "displayName",
     "displayDescription",
     "shortName",

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -47,6 +47,7 @@ function getError(key: string, namespace: Maybe<Dictionary<string>> = undefined)
 
 interface DataSetWithAttributes {
     id: string;
+    name: string;
     attributeValues: AttributeValue[];
 }
 
@@ -523,7 +524,7 @@ export default class Campaign {
             },
         });
 
-        const namesFilters = dashboards.map(d => `name:like:${d.name.replace("_DASHBOARD", "")}`);
+        const namesFilters = dataSets.map(d => `name:like$:${d.name}`);
         const { categoryOptions: teams } = await db.api.get("/categoryOptions", {
             fields: ["id,name"],
             filter: namesFilters,

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -528,19 +528,12 @@ export default class Campaign {
 
         const campaignNames = dataSets.map(d => d.name);
 
-        const options = _.isEmpty(campaignNames)
-            ? {
-                  fields: ["id,name,categories[id]"],
-                  paging: false,
-              }
-            : {
-                  fields: ["id,name,categories[id]"],
-                  filter: campaignNames.map(cn => `name:like$:${cn}`),
-                  rootJunction: "OR",
-                  paging: false,
-              };
-
-        const { categoryOptions: teams } = await db.api.get("/categoryOptions", options);
+        const { categoryOptions: teams } = await db.api.get("/categoryOptions", {
+            fields: ["id,name,categories[id]"],
+            filter: campaignNames.map(cn => `name:like$:${cn}`),
+            rootJunction: "OR",
+            paging: false,
+        });
 
         const teamsCategoyId = _(config.categories)
             .keyBy("code")

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -212,7 +212,7 @@ export default class Campaign {
     ): Promise<Response<string>> {
         const modelReferencesToDelete = await this.getResources(config, db, dataSets);
 
-        return db.deleteMany(modelReferencesToDelete);
+        return db.deleteMany(modelReferencesToDelete, ["categoryOptions"]);
     }
 
     public async validate(

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -502,6 +502,8 @@ export default class Campaign {
         db: DbD2,
         dataSets: DataSetWithAttributes[]
     ) {
+        if (_.isEmpty(dataSets)) return [];
+
         const dashboardIds = _(dataSets)
             .flatMap(dataSet => dataSet.attributeValues)
             .filter(attrVal => attrVal.attribute.code === config.attributeCodeForDashboard)

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -4,6 +4,7 @@ import Campaign from "./campaign";
 
 const fields = [
     "id",
+    "name",
     "displayName",
     "displayDescription",
     "shortName",

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -371,8 +371,7 @@ export default class DbD2 {
                                 status: "OK",
                                 message: `Deletion of ${model} resources failed but are ignored`,
                             };
-                        }
-                        if (err.httpStatusCode) {
+                        } else if (err.httpStatusCode) {
                             return err;
                         } else {
                             throw err;

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -355,12 +355,23 @@ export default class DbD2 {
         }
     }
 
-    public async deleteMany(modelReferences: ModelReference[]): Promise<Response<string>> {
+    public async deleteMany(
+        modelReferences: ModelReference[],
+        ignoreErrorsFrom: string[] = []
+    ): Promise<Response<string>> {
         const errors = _.compact(
             await promiseMap(modelReferences, async ({ model, id }) => {
                 const { httpStatus, httpStatusCode, status, message } = await this.api
                     .delete(`/${model}/${id}`)
                     .catch((err: DeleteResponse) => {
+                        if (_.includes(ignoreErrorsFrom, model)) {
+                            return {
+                                httpStatus: "OK",
+                                httpStatusCode: 204,
+                                status: "OK",
+                                message: `Deletion of ${model} resources failed but are ignored`,
+                            };
+                        }
                         if (err.httpStatusCode) {
                             return err;
                         } else {


### PR DESCRIPTION
### :pushpin: References

* **Issue:**  #191 

### :memo: Implementation-
Due to categoryOptionCombos being created once data was entered into the campaign, team deletion was failing. We've (@tokland) decided to try to delete the teams but ignore errors if deletion fails. Also implemented this for editing a campaign, which would have the same problem.

Also fixed unrelated issue with deletion on cypress list test

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?
Campaign must be created -> Data entered -> Analytics Runned.


