### PR TITLE
[data entry] Disable autocomplete for input fields in custom form

### DIFF
--- a/src/models/DataSetCustomForm.ts
+++ b/src/models/DataSetCustomForm.ts
@@ -34,6 +34,7 @@ function inputTd(dataElementId: string, cocId: string): string {
             name: "entryfield",
             class: "entryfield",
             id: `${dataElementId}-${cocId}-val`,
+            autocomplete: "off",
         })
     );
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #213

### :memo: Implementation

- Add `autocomplete="off"` to input text field.

Existing campaigns must be re-saved so the custom form in dataset is updated.