### PR TITLE
If user has not orgUnits, shown empty tree and show snackbar error

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-11T11:20:40.971Z\n"
-"PO-Revision-Date: 2019-07-11T11:20:40.971Z\n"
+"POT-Creation-Date: 2019-07-16T08:46:57.652Z\n"
+"PO-Revision-Date: 2019-07-16T08:46:57.652Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -258,6 +258,9 @@ msgstr ""
 msgid "Field cannot be blank"
 msgstr ""
 
+msgid "This user has no Data output and analytic organisation units assigned"
+msgstr ""
+
 msgid "Number of Teams"
 msgstr ""
 
@@ -276,18 +279,6 @@ msgstr ""
 msgid "[{{total}}] {{names}} and {{othersCount}} other(s)"
 msgstr ""
 
-msgid "Missing"
-msgstr ""
-
-msgid "Unknown"
-msgstr ""
-
-msgid "Total population"
-msgstr ""
-
-msgid "Age distribution"
-msgstr ""
-
 msgid "Period dates"
 msgstr ""
 
@@ -304,6 +295,12 @@ msgid "Population distribution (%)"
 msgstr ""
 
 msgid "Campaign Population Distribution"
+msgstr ""
+
+msgid "Total population"
+msgstr ""
+
+msgid "Missing"
 msgstr ""
 
 msgid "Cancel Campaign Creation?"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-07-04T07:22:42.893Z\n"
+"POT-Creation-Date: 2019-07-16T08:46:57.652Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -99,11 +99,12 @@ msgid ""
 "any of the following actions -> Set Target Population, Go to Data Entry, Go "
 "To Dashboards, See Details, Edit or Delete."
 msgstr ""
-"Haga clic en el botón azul para crear una nueva campaña o seleccione una campaña "
-"creada anteriormente a la que desee acceder.\n"
-"Haga clic en los tres puntos al lado derecho de la pantalla si desea realizar alguna "
-"de las siguientes acciones -> Establecer población objetivo, Ir a Entrada de datos, "
-"Ir a Tableros de mandos, Ver detalles, Editar o Eliminar.""
+"Haga clic en el botón azul para crear una nueva campaña o seleccione una "
+"campaña creada anteriormente a la que desee acceder.\n"
+"Haga clic en los tres puntos al lado derecho de la pantalla si desea "
+"realizar alguna de las siguientes acciones -> Establecer población objetivo, "
+"Ir a Entrada de datos, Ir a Tableros de mandos, Ver detalles, Editar o "
+"Eliminar."
 
 msgid "Create Campaign"
 msgstr "Crear Campaña"
@@ -314,6 +315,9 @@ msgstr "Desagregación"
 msgid "Field cannot be blank"
 msgstr "El campo no puede estar vacío"
 
+msgid "This user has no Data output and analytic organisation units assigned"
+msgstr "Este usuario no tiene unidades organizativas de datos y análisis asignadas"
+
 msgid "Number of Teams"
 msgstr "Número de equipos"
 
@@ -332,18 +336,6 @@ msgstr "[Vacío]"
 msgid "[{{total}}] {{names}} and {{othersCount}} other(s)"
 msgstr "[{{total}}] {{names}} y {{othersCount}} otros"
 
-msgid "Missing"
-msgstr "Vacío"
-
-msgid "Unknown"
-msgstr "Desconocido"
-
-msgid "Total population"
-msgstr "Población total"
-
-msgid "Age distribution"
-msgstr "Distribución por edad (%)"
-
 msgid "Period dates"
 msgstr "Periodo"
 
@@ -361,6 +353,12 @@ msgstr "Distribución por edad (%)"
 
 msgid "Campaign Population Distribution"
 msgstr "Distribución de población"
+
+msgid "Total population"
+msgstr "Población total"
+
+msgid "Missing"
+msgstr "Vacío"
 
 msgid "Cancel Campaign Creation?"
 msgstr "¿Cancelar la creación de campaña?"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-07-04T07:22:42.893Z\n"
+"POT-Creation-Date: 2019-07-16T08:46:57.652Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -66,7 +66,8 @@ msgid "Set Target Population"
 msgstr "Définir population cible"
 
 msgid "Deleting campaign(s). This may take a while, please wait"
-msgstr "Suppression de campagne(s). Cela peut prendre un moment, veuillez patienter"
+msgstr ""
+"Suppression de campagne(s). Cela peut prendre un moment, veuillez patienter"
 
 msgid "Campaign(s) deleted"
 msgstr "Campagne(s) supprimée(s)"
@@ -98,8 +99,12 @@ msgid ""
 "any of the following actions -> Set Target Population, Go to Data Entry, Go "
 "To Dashboards, See Details, Edit or Delete."
 msgstr ""
-"Cliquez sur le bouton bleu pour créer une nouvelle campagne ou sélectionnez une campagne précédemment créée à laquelle vous souhaitez accéder.\n"
-"Cliquez sur les trois points à droite de l'écran si vous souhaitez effectuer l'une des opérations suivantes -> Définir la population cible, Aller à la saisie de données, Aller au Tableau de bord, Afficher les détails, Modifier ou Supprimer."
+"Cliquez sur le bouton bleu pour créer une nouvelle campagne ou sélectionnez "
+"une campagne précédemment créée à laquelle vous souhaitez accéder.\n"
+"Cliquez sur les trois points à droite de l'écran si vous souhaitez effectuer "
+"l'une des opérations suivantes -> Définir la population cible, Aller à la "
+"saisie de données, Aller au Tableau de bord, Afficher les détails, Modifier "
+"ou Supprimer."
 
 msgid "Create Campaign"
 msgstr "Créer une campagne"
@@ -270,8 +275,9 @@ msgid ""
 "It loooks like it's the first time you are accessing the dashboard for this "
 "campaign. Generating dashboard. This may take up to a couple of minutes"
 msgstr ""
-"On dirait que c'est la première fois que vous accédez au tableau de bord pour cela "
-"campagne. Générer un tableau de bord. Cela peut prendre quelques minutes"
+"On dirait que c'est la première fois que vous accédez au tableau de bord "
+"pour cela campagne. Générer un tableau de bord. Cela peut prendre quelques "
+"minutes"
 
 msgid ""
 "Please click on the grey arrow next to the chart/table title if you want to "
@@ -313,6 +319,9 @@ msgstr "Subdivision"
 msgid "Field cannot be blank"
 msgstr "Le champ ne peut pas être vide"
 
+msgid "This user has no Data output and analytic organisation units assigned"
+msgstr "N'a pas attribué d'unités d'organisation de sortie de données et d'analyse"
+
 msgid "Number of Teams"
 msgstr "Nombre d'équipes"
 
@@ -331,18 +340,6 @@ msgstr "[None]"
 msgid "[{{total}}] {{names}} and {{othersCount}} other(s)"
 msgstr "[{{total}}] {{names}} et {{othersCount}} autre (s)"
 
-msgid "Missing"
-msgstr "Manquant"
-
-msgid "Unknown"
-msgstr "Inconnu"
-
-msgid "Total population"
-msgstr "Population totale"
-
-msgid "Age distribution"
-msgstr "Répartition par âge (%)"
-
 msgid "Period dates"
 msgstr "Période"
 
@@ -360,6 +357,12 @@ msgstr "Répartition de la population (%)"
 
 msgid "Campaign Population Distribution"
 msgstr "Répartition de la population de la campagne"
+
+msgid "Total population"
+msgstr "Population totale"
+
+msgid "Missing"
+msgstr "Manquant"
 
 msgid "Cancel Campaign Creation?"
 msgstr "Annuler la création de campagne?"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "classnames": "^2.2.6",
         "d2": "^31",
         "d2-manifest": "^1.0.0",
-        "d2-ui-components": "0.0.20",
+        "d2-ui-components": "0.0.21",
         "enzyme": "^3.7.0",
         "enzyme-adapter-react-16": "^1.6.0",
         "enzyme-to-json": "^3.3.4",

--- a/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
+++ b/src/components/steps/organisation-units/OrganisationUnitsStep.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import _ from "lodash";
 import i18n from "@dhis2/d2-i18n";
-import { OrgUnitsSelector } from "d2-ui-components";
+import { OrgUnitsSelector, withSnackbar } from "d2-ui-components";
 import { FormBuilder } from "@dhis2/d2-ui-forms";
 import { TextField } from "@dhis2/d2-ui-core";
 import { Validators } from "@dhis2/d2-ui-forms";
@@ -21,6 +21,7 @@ class OrganisationUnitsStep extends React.Component {
         d2: PropTypes.object.isRequired,
         campaign: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
+        snackbar: PropTypes.object.isRequired,
     };
 
     listParams = { maxLevel: 5 };
@@ -34,7 +35,15 @@ class OrganisationUnitsStep extends React.Component {
     constructor(props) {
         super(props);
         const orgUnitIds = getCurrentUserDataViewOrganisationUnits(this.props.d2);
-        this.rootIds = _(orgUnitIds).isEmpty() ? undefined : orgUnitIds;
+        this.rootIds = orgUnitIds;
+    }
+
+    componentDidMount() {
+        if (_(this.rootIds).isEmpty()) {
+            this.props.snackbar.error(
+                i18n.t("This user has no Data output and analytic organisation units assigned")
+            );
+        }
     }
 
     setOrgUnits = orgUnitsPaths => {
@@ -115,4 +124,4 @@ const styles = {
     formBuilder: { marginBottom: 20 },
 };
 
-export default OrganisationUnitsStep;
+export default withSnackbar(OrganisationUnitsStep);


### PR DESCRIPTION
# :pushpin: References

* **Issue:** Closes #231 
* d2-ui-components updated to 0.0.21 (just released).

### :memo: Implementation

Now if a user has no data output/analysis orgUnits: 
- Show an empty org unit tree (before, it rendered the full tree)
- Show snackbar error.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/61280986-24d15e00-a7b9-11e9-9761-e9bb61754f32.png)