### PR TITLE
Set same dashboard sharings to its favorites

### DIFF
--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -182,7 +182,8 @@ export class Dashboard {
             datasetName,
             startDate,
             endDate,
-            dashboardItemsMetadata
+            dashboardItemsMetadata,
+            sharing
         );
 
         const keys: Array<keyof allDashboardElements> = ["items", "charts", "reportTables"];
@@ -206,7 +207,8 @@ export class Dashboard {
         datasetName: String,
         startDate: Moment,
         endDate: Moment,
-        dashboardItemsMetadata: Dictionary<any>
+        dashboardItemsMetadata: Dictionary<any>,
+        sharing: Sharing
     ): allDashboardElements {
         const { organisationUnitsWithName, legendMetadata } = dashboardItemsMetadata;
         const organisationUnitsMetadata = organisationUnitsWithName.map(
@@ -260,10 +262,17 @@ export class Dashboard {
 
         const dashboardData = {
             items: [...dashboardCharts, ...dashboardTables],
-            charts,
-            reportTables,
+            charts: addSharing(sharing, charts),
+            reportTables: addSharing(sharing, reportTables),
         };
 
         return dashboardData;
     }
+}
+
+function addSharing(sharing: Sharing, objects: object[]): object[] {
+    return objects.map(object => ({
+        ...object,
+        ...sharing,
+    }));
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #253 

### :memo: Implementation

- Use exactly the same sharing (public/user/group accesses) of dashboard for its favorites (charts, report tables). As described in #253, there is no need to (we can't) set sharing for the dashboard items themselves.