### PR TITLE
Set attribute hideInTallySheet=true for campaign data sets

### DIFF
--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -78,7 +78,6 @@ export default class CampaignDb {
         const { campaign } = this;
         const { db, config: metadataConfig, teamsMetadata } = campaign;
         const dataSetId = campaign.id || generateUid();
-        const { app: attributeForApp } = metadataConfig.attributes;
 
         if (!campaign.startDate || !campaign.endDate) {
             return { status: false, error: "Campaign Dates not set" };
@@ -135,7 +134,10 @@ export default class CampaignDb {
             expiryDays: 0,
             formType: "CUSTOM",
             dataInputPeriods,
-            attributeValues: [{ value: "true", attribute: { id: attributeForApp.id } }],
+            attributeValues: [
+                { value: "true", attribute: { id: metadataConfig.attributes.app.id } },
+                { value: "true", attribute: { id: metadataConfig.attributes.hideInTallySheet.id } },
+            ],
             dataEntryForm: { id: dataEntryForm.id },
             sections: sections.map(section => ({ id: section.id })),
             ...sharing,

--- a/src/models/CampaignSharing.ts
+++ b/src/models/CampaignSharing.ts
@@ -31,7 +31,7 @@ interface UserGroupsSharingFilter {
 interface UsersByOrgUnitsSharingFilter {
     type: "usersByOrgUnits";
     level: number;
-    userRolesGroups: Array<string[]>;
+    userRoles: Array<string[]>;
     permission: ObjectPermission;
 }
 
@@ -39,7 +39,7 @@ interface UsersByOrgUnitsInGroupSetSharingFilter {
     type: "usersByOrgUnitsInGroupSet";
     level: number;
     organisationUnitGroupSetName: string;
-    userRolesGroups: Array<string[]>;
+    userRoles: Array<string[]>;
     permission: ObjectPermission;
 }
 
@@ -125,7 +125,7 @@ export default class CampaignSharing {
                 {
                     type: "usersByOrgUnits",
                     level: 4,
-                    userRolesGroups: [
+                    userRoles: [
                         ["RVC App"],
                         ["Medical Focal Point", "Field User", "Online Data Entry"],
                     ],
@@ -134,14 +134,14 @@ export default class CampaignSharing {
                 {
                     type: "usersByOrgUnits",
                     level: 3,
-                    userRolesGroups: [["MedCo"]],
+                    userRoles: [["MedCo"]],
                     permission: { metadata: "edit" },
                 },
                 {
                     type: "usersByOrgUnitsInGroupSet",
                     level: 3,
                     organisationUnitGroupSetName: "8. Operational Cells",
-                    userRolesGroups: [["TesaCo"]],
+                    userRoles: [["TesaCo"]],
                     permission: { metadata: "edit" },
                 },
             ],
@@ -290,18 +290,18 @@ function getAccesses<K extends keyof UserAndGroupAccesses>(
 
 function getUserAccessesFilteredByRoles(
     users: User[],
-    sharing: { userRolesGroups: Array<string[]>; permission: ObjectPermission }
+    sharing: { userRoles: Array<string[]>; permission: ObjectPermission }
 ) {
-    const userMatchesSomeUserRole = (user: User) => {
+    const userMatchesUserRoles = (user: User) => {
         const userRoles = user.userCredentials ? user.userCredentials.userRoles : [];
         const userRoleNames = userRoles.map(userRole => userRole.name);
-        return sharing.userRolesGroups.every(
-            userRoleGroup => _.intersection(userRoleNames, userRoleGroup).length > 0
+        return sharing.userRoles.every(
+            expectedUserRoles => _.intersection(userRoleNames, expectedUserRoles).length > 0
         );
     };
 
     const userAccesses = _(users)
-        .filter(userMatchesSomeUserRole)
+        .filter(userMatchesUserRoles)
         .map(user => ({
             id: user.id,
             displayName: user.displayName,

--- a/src/models/__tests__/config-mock.ts
+++ b/src/models/__tests__/config-mock.ts
@@ -23,6 +23,12 @@ const metadataConfig: MetadataConfig = {
             displayName: "Created by app",
             valueType: "BOOLEAN",
         },
+        hideInTallySheet: {
+            id: "2",
+            code: "",
+            displayName: "hideInTallySheet",
+            valueType: "BOOLEAN",
+        },
     },
     categories: [],
     categoriesDisaggregation: [

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -29,6 +29,7 @@ export const baseConfig = {
     categoryCodeForTeams: "RVC_TEAM",
     legendSetsCode: "RVC_LEGEND_ZERO",
     attributeCodeForApp: "RVC_CREATED_BY_VACCINATION_APP",
+    attributeNameForHideInTallySheet: "hideInTallySheet",
     dataElementCodeForTotalPopulation: "RVC_TOTAL_POPULATION",
     dataElementCodeForAgeDistribution: "RVC_AGE_DISTRIBUTION",
     dataElementCodeForPopulationByAge: "RVC_POPULATION_BY_AGE",
@@ -46,6 +47,7 @@ export interface MetadataConfig extends BaseConfig {
     userRoles: NamedObject[];
     attributes: {
         app: Attribute;
+        hideInTallySheet: Attribute;
     };
     organisationUnitLevels: OrganisationUnitLevel[];
     categories: Category[];
@@ -287,9 +289,12 @@ function getPopulationMetadata(
 }
 
 function getAttributes(attributes: Attribute[]) {
-    const attributesByCode = _(attributes).keyBy("code");
+    const attributesByCode = _(attributes).keyBy(attribute => attribute.code);
+    const attributesByName = _(attributes).keyBy(attribute => attribute.displayName);
+
     return {
         app: attributesByCode.getOrFail(baseConfig.attributeCodeForApp),
+        hideInTallySheet: attributesByName.getOrFail(baseConfig.attributeNameForHideInTallySheet),
     };
 }
 
@@ -327,7 +332,7 @@ export async function getMetadataConfig(db: DbD2): Promise<MetadataConfig> {
     const modelParams = { filters: [codeFilter] };
 
     const metadataParams = {
-        attributes: modelParams,
+        attributes: {},
         categories: modelParams,
         categoryCombos: modelParams,
         categoryOptionGroups: modelParams,


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #255

### :memo: Implementation

- This attribute has no code, so we get it by name (`name="hideInTallySheet"`) and post it within `dataSet.attributeValues`.