### PR TITLE
Show campaigns in user orgunits

### DIFF
--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -85,13 +85,11 @@ describe("Campaigns - Create", () => {
         cy.contains("Organisation Units");
         cy.contains("MSF -> OCBA -> ETHIOPIA -> ETHIOPIA, MERT -> Cholera Intervention Addis 2016");
 
-        cy.route("POST", "/api/metadata").as("metadataRequest");
         cy.get("[data-wizard-contents] button")
             .contains("Save")
             .click();
 
-        cy.wait("@metadataRequest");
-        cy.contains("Campaign created");
+        cy.contains("Campaign created", { timeout: 60000 });
     });
 });
 
@@ -149,7 +147,7 @@ function deleteAllTestResources() {
         const dataSet = dataSets[0];
         cy.request({
             method: "GET",
-            url: getApiUrl(`/dashboards?filter=code:eq:RVC_CAMPAIGN_${dataSet.id}`),
+            url: getApiUrl(`/dashboards?filter=code:eq:RVC_CAMPAIGN_${dataSet.id}&fields=:owner`),
             failOnStatusCode: false,
         }).then(({ body: { dashboards: [dashboard] } }) => {
             cy.request({

--- a/cypress/integration/campaign-configurator/list.spec.js
+++ b/cypress/integration/campaign-configurator/list.spec.js
@@ -29,10 +29,6 @@ describe("Campaigns - List page", () => {
         });
     });
 
-    it("should have the filter only my campaign set by default", () => {
-        cy.get("[data-test='only-my-campaigns']").should("be.checked");
-    });
-
     it("shows list of user campaigns", () => {
         cy.get(".data-table__rows > :nth-child(3) > :nth-child(4) span").should("not.be.empty");
     });
@@ -58,8 +54,6 @@ describe("Campaigns - List page", () => {
     });
 
     it("shows list of user dataset sorted alphabetically", () => {
-        cy.get("[data-test='only-my-campaigns']").uncheck();
-
         cy.get(".data-table__rows > :nth-child(1) > :nth-child(2) span").then(text1 => {
             cy.get(".data-table__rows > :nth-child(2) > :nth-child(2) span").then(text2 => {
                 assert.isTrue(text1.text() < text2.text());
@@ -82,8 +76,6 @@ describe("Campaigns - List page", () => {
     });
 
     it("can filter datasets by name (case insensitive)", () => {
-        cy.get("[data-test='only-my-campaigns']").uncheck();
-
         cy.get("[data-test='search']")
             .clear()
             .type("cypress");

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-07-17T10:59:03.202Z\n"
-"PO-Revision-Date: 2019-07-17T10:59:03.202Z\n"
+"POT-Creation-Date: 2019-08-09T11:42:16.869Z\n"
+"PO-Revision-Date: 2019-08-09T11:42:16.869Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -72,9 +72,6 @@ msgid "Campaign(s) deleted"
 msgstr ""
 
 msgid "Error deleting campaign(s)"
-msgstr ""
-
-msgid "Only my campaigns"
 msgstr ""
 
 msgid ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-07-17T10:53:32.880Z\n"
+"POT-Creation-Date: 2019-08-09T11:42:16.869Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -73,9 +73,6 @@ msgstr "Campaña(s) eliminadas"
 
 msgid "Error deleting campaign(s)"
 msgstr "Se produjo un error al borrar la(s) campaña(s)"
-
-msgid "Only my campaigns"
-msgstr "Solo mis campañas"
 
 msgid ""
 "Are you sure you want to delete those campaign(s) (datasets and dashboards)? "
@@ -317,7 +314,8 @@ msgstr "El campo no puede estar vacío"
 
 msgid "This user has no Data output and analytic organisation units assigned"
 msgstr ""
-"Este usuario no tiene unidades organizativas configuradas en la sección de resultados y análisis"
+"Este usuario no tiene unidades organizativas configuradas en la sección de "
+"resultados y análisis"
 
 msgid "Number of Teams"
 msgstr "Número de equipos"
@@ -397,16 +395,19 @@ msgstr ""
 "probablemente hay datos asociados"
 
 msgid "Coverage by Site {{- period}} (do not edit this chart)"
-msgstr "Cobertura Vacunal por Centro Salud {{- period}} (no edite esta gráfica)"
+msgstr ""
+"Cobertura Vacunal por Centro Salud {{- period}} (no edite esta gráfica)"
 
 msgid "Coverage by Area {{- period}} (do not edit this chart)"
-msgstr "Cobertura Vacunal por área de Salud {{- period}} (no edite esta gráfica)"
+msgstr ""
+"Cobertura Vacunal por área de Salud {{- period}} (no edite esta gráfica)"
 
 msgid "Global QS Indicators"
 msgstr "Indicadores globales de Calidad y Seguridad"
 
 msgid "AEFI and AEB indicators"
-msgstr "Exposición Accidental a Sangre y Efecto Adverso Posterior a la Vacunación"
+msgstr ""
+"Exposición Accidental a Sangre y Efecto Adverso Posterior a la Vacunación"
 
 msgid "Campaign Coverage by area (do not edit this table)"
 msgstr "Cobertura Vacunal por Área de Salud (no edite esta tabla)"
@@ -468,3 +469,6 @@ msgstr ""
 
 msgid "There already exists a campaign with the same name"
 msgstr "Ya existe una campaña con el mismo nombre"
+
+#~ msgid "Only my campaigns"
+#~ msgstr "Solo mis campañas"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2019-07-17T10:53:32.880Z\n"
+"POT-Creation-Date: 2019-08-09T11:42:16.869Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,9 +74,6 @@ msgstr "Campagne(s) supprimée(s)"
 
 msgid "Error deleting campaign(s)"
 msgstr "Erreur lors de la suppression de la / des campagne(s)"
-
-msgid "Only my campaigns"
-msgstr "Seulement mes campagnes"
 
 msgid ""
 "Are you sure you want to delete those campaign(s) (datasets and dashboards)? "
@@ -321,7 +318,8 @@ msgstr "Le champ ne peut pas être vide"
 
 msgid "This user has no Data output and analytic organisation units assigned"
 msgstr ""
-"Cet utilisateur n'a pas d'unité d'organisation de configuré dans l´option de resultat et d´analyse"
+"Cet utilisateur n'a pas d'unité d'organisation de configuré dans l´option de "
+"resultat et d´analyse"
 
 msgid "Number of Teams"
 msgstr "Nombre d'équipes"
@@ -404,7 +402,9 @@ msgid "Coverage by Site {{- period}} (do not edit this chart)"
 msgstr "Couverture Vaccinale par Site de Santé (ne modifiez pas ce graphique)"
 
 msgid "Coverage by Area {{- period}} (do not edit this chart)"
-msgstr "Couverture Vaccinale par Zone de Santé {{- period}} (ne modifiez pas ce graphique)"
+msgstr ""
+"Couverture Vaccinale par Zone de Santé {{- period}} (ne modifiez pas ce "
+"graphique)"
 
 msgid "Global QS Indicators"
 msgstr "Indicateurs globaux de Qualité et de Sécurité"
@@ -474,3 +474,6 @@ msgstr ""
 
 msgid "There already exists a campaign with the same name"
 msgstr "Il existe déjà une campagne du même nom"
+
+#~ msgid "Only my campaigns"
+#~ msgstr "Seulement mes campagnes"

--- a/src/components/campaign-configuration/CampaignConfiguration.jsx
+++ b/src/components/campaign-configuration/CampaignConfiguration.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import i18n from "@dhis2/d2-i18n";
 import { ConfirmationDialog, ObjectsTable, withSnackbar, withLoading } from "d2-ui-components";
 import _ from "lodash";
-import Checkbox from "material-ui/Checkbox/Checkbox";
 
 import PageHeader from "../shared/PageHeader";
 import { list } from "../../models/datasets";
@@ -31,9 +30,7 @@ class CampaignConfiguration extends React.Component {
             dataSetsToDelete: null,
             targetPopulationDataSet: null,
             objectsTableKey: new Date(),
-            filters: {
-                showOnlyUserCampaigns: true,
-            },
+            filters: {},
         };
     }
 
@@ -188,26 +185,6 @@ class CampaignConfiguration extends React.Component {
         this.props.history.push("/campaign-configuration/new");
     };
 
-    toggleShowOnlyUserCampaigns = ev => {
-        const newFilters = { showOnlyUserCampaigns: ev.target.checked };
-        this.setState(state => ({ filters: { ...state.filters, ...newFilters } }));
-    };
-
-    renderCustomFilters = () => {
-        const { showOnlyUserCampaigns } = this.state.filters;
-
-        return (
-            <Checkbox
-                style={styles.checkbox}
-                checked={showOnlyUserCampaigns}
-                data-test="only-my-campaigns"
-                label={i18n.t("Only my campaigns")}
-                onCheck={this.toggleShowOnlyUserCampaigns}
-                iconStyle={styles.checkboxIcon}
-            />
-        );
-    };
-
     list = (...listArgs) => {
         const { config } = this.props;
         return list(config, ...listArgs);
@@ -268,7 +245,6 @@ Click the three dots on the right side of the screen if you wish to perform any 
                         onButtonClick={this.isCurrentUserManager ? this.onCreate : null}
                         list={this.list}
                         buttonLabel={i18n.t("Create Campaign")}
-                        customFiltersComponent={this.renderCustomFilters}
                         customFilters={this.state.filters}
                     />
                 </div>
@@ -288,8 +264,6 @@ Click the three dots on the right side of the screen if you wish to perform any 
 }
 
 const styles = {
-    checkbox: { float: "left", width: "25%", paddingTop: 18, marginLeft: 30 },
-    checkboxIcon: { marginRight: 8 },
     objectsTableContainer: { marginTop: -10 },
 };
 

--- a/src/components/campaign-configuration/CampaignConfiguration.jsx
+++ b/src/components/campaign-configuration/CampaignConfiguration.jsx
@@ -262,6 +262,4 @@ Click the three dots on the right side of the screen if you wish to perform any 
     }
 }
 
-const styles = {};
-
 export default withLoading(withSnackbar(withPageVisited(CampaignConfiguration, "config")));

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -9,8 +9,6 @@ const expectedFields = [
     "created",
     "lastUpdated",
     "publicAccess",
-    "userAccesses",
-    "userGroupAccesses",
     "user",
     "dataInputPeriods~paging=(1;1)",
     "href",

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -4,24 +4,22 @@ import metadataConfig from "./config-mock";
 
 const expectedFields = [
     "id",
-    "name",
     "displayName",
     "displayDescription",
-    "shortName",
     "created",
     "lastUpdated",
-    "externalAccess",
     "publicAccess",
     "userAccesses",
     "userGroupAccesses",
     "user",
-    "access",
-    "attributeValues[value, attribute[code]]",
     "dataInputPeriods~paging=(1;1)",
     "href",
+    "attributeValues[value, attribute[code]]",
+    "organisationUnits[id,path]",
 ];
 
-const emptyCollection = { pager: {}, toArray: () => [] };
+const createdByAppFilter = "attributeValues.attribute.code:eq:RVC_CREATED_BY_VACCINATION_APP";
+const emptyCollection = { pager: { page: 1, total: 0 }, toArray: () => [] };
 const listMock = jest.fn(() => Promise.resolve(emptyCollection));
 
 describe("DataSets", () => {
@@ -31,22 +29,11 @@ describe("DataSets", () => {
                 const d2 = getD2Stub({ models: { dataSets: { list: listMock } } });
                 await list(metadataConfig, d2, {}, {});
 
-                expect(d2.models.dataSets.list).toHaveBeenNthCalledWith(1, {
-                    fields: ["id", "attributeValues[value, attribute[code]]"],
-                    paging: false,
-                    filter: `attributeValues.attribute.code:eq:${
-                        metadataConfig.attributeCodeForApp
-                    }`,
+                expect(d2.models.dataSets.list).toHaveBeenCalledWith({
+                    fields: expectedFields.join(","),
+                    pageSize: 1000,
+                    filter: [createdByAppFilter],
                 });
-
-                expect(d2.models.dataSets.list).toHaveBeenLastCalledWith({
-                    fields: expectedFields,
-                    order: undefined,
-                    page: undefined,
-                    pageSize: 20,
-                    filter: ["id:in:[]"],
-                });
-                expect(d2.models.dataSets.list).toHaveBeenCalledTimes(2);
             });
         });
 
@@ -58,7 +45,6 @@ describe("DataSets", () => {
                 });
                 const filters = {
                     search: "abc",
-                    showOnlyUserCampaigns: true,
                 };
                 const pagination = {
                     page: 2,
@@ -68,11 +54,10 @@ describe("DataSets", () => {
                 await list(metadataConfig, d2, filters, pagination);
 
                 expect(d2.models.dataSets.list).toHaveBeenCalledWith({
-                    fields: expectedFields,
+                    fields: expectedFields.join(","),
+                    pageSize: 1000,
+                    filter: ["displayName:ilike:abc", createdByAppFilter],
                     order: "displayName:idesc",
-                    page: 2,
-                    pageSize: 10,
-                    filter: ["displayName:ilike:abc", "user.id:eq:b123123123", "id:in:[]"],
                 });
             });
         });
@@ -81,25 +66,92 @@ describe("DataSets", () => {
             it("returns only datasets with the CREATED_BY_VACCINATION attribute set", async () => {
                 const testIds = ["id1", "id2", "id3", "id4"];
                 const attribute = metadataConfig.attributes.app;
+                const organisationUnits = {
+                    toArray: () => [{ path: "/1/10/100" }, { path: "/1/11" }],
+                };
                 const testDataSets = [
-                    { id: testIds[0], attributeValues: [{ value: "true", attribute }] },
-                    { id: testIds[1], attributeValues: [{ value: "false", attribute }] },
-                    { id: testIds[2], attributeValues: [{ value: "true", attribute }] },
-                    { id: testIds[3], attributeValues: [{ value: "false", attribute }] },
+                    {
+                        id: testIds[0],
+                        attributeValues: [{ value: "true", attribute }],
+                        organisationUnits,
+                    },
+                    {
+                        id: testIds[1],
+                        attributeValues: [{ value: "false", attribute }],
+                        organisationUnits,
+                    },
+                    {
+                        id: testIds[2],
+                        attributeValues: [{ value: "true", attribute }],
+                        organisationUnits,
+                    },
+                    {
+                        id: testIds[3],
+                        attributeValues: [{ value: "false", attribute }],
+                        organisationUnits,
+                    },
                 ];
                 const listMock = jest.fn(() =>
                     Promise.resolve({ toArray: () => testDataSets, pager: {} })
                 );
-                const d2 = getD2Stub({ models: { dataSets: { list: listMock } } });
-                await list(metadataConfig, d2, {}, {});
-
-                expect(d2.models.dataSets.list).toHaveBeenLastCalledWith({
-                    fields: expectedFields,
-                    order: undefined,
-                    page: undefined,
-                    pageSize: 20,
-                    filter: [`id:in:[${testIds[0]},${testIds[2]}]`],
+                const d2 = getD2Stub({
+                    models: { dataSets: { list: listMock } },
                 });
+
+                d2.currentUser[Symbol.for("dataViewOrganisationUnits")] = ["1"];
+
+                const { pager, objects: dataSets } = await list(metadataConfig, d2, {}, {});
+
+                expect(dataSets.map(ds => ds.id).sort()).toEqual([testIds[0], testIds[2]].sort());
+                expect(pager).toEqual({ page: 1, total: 2 });
+            });
+        });
+
+        describe("filters datasets by user dataView organisation units", () => {
+            it("returns only datasets if current user dataView orgUnits all match", async () => {
+                const testIds = ["id1", "id2", "id3", "id4"];
+                const attribute = metadataConfig.attributes.app;
+                const attributeValues = [{ value: "true", attribute }];
+                const testDataSets = [
+                    {
+                        id: testIds[0],
+                        attributeValues,
+                        organisationUnits: {
+                            toArray: () => [{ path: "/1/10/100" }, { path: "/1/11" }],
+                        },
+                    },
+                    {
+                        id: testIds[1],
+                        attributeValues,
+                        organisationUnits: {
+                            toArray: () => [{ path: "/1/10/100" }],
+                        },
+                    },
+                    {
+                        id: testIds[2],
+                        attributeValues,
+                        organisationUnits: {
+                            toArray: () => [{ path: "/1/11" }],
+                        },
+                    },
+                ];
+                const listMock = jest.fn(() =>
+                    Promise.resolve({ toArray: () => testDataSets, pager: {} })
+                );
+                const d2 = getD2Stub({
+                    models: { dataSets: { list: listMock } },
+                });
+                d2.currentUser[Symbol.for("dataViewOrganisationUnits")] = ["1"];
+
+                const { objects: dataSets1 } = await list(metadataConfig, d2, {}, {});
+                expect(dataSets1.map(ds => ds.id).sort()).toEqual(
+                    [testIds[0], testIds[1], testIds[2]].sort()
+                );
+
+                d2.currentUser[Symbol.for("dataViewOrganisationUnits")] = ["10"];
+
+                const { objects: dataSets2 } = await list(metadataConfig, d2, {}, {});
+                expect(dataSets2.map(ds => ds.id).sort()).toEqual([testIds[1]].sort());
             });
         });
     });

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -1,65 +1,86 @@
 import _ from "lodash";
+import { getCurrentUserDataViewOrganisationUnits } from "../utils/dhis2";
 
-const fields = [
+const requiredFields = ["attributeValues[value, attribute[code]]", "organisationUnits[id,path]"];
+
+const defaultListFields = [
     "id",
-    "name",
     "displayName",
     "displayDescription",
-    "shortName",
     "created",
     "lastUpdated",
-    "externalAccess",
     "publicAccess",
     "userAccesses",
     "userGroupAccesses",
     "user",
-    "access",
-    "attributeValues[value, attribute[code]]",
     "dataInputPeriods~paging=(1;1)",
     "href",
 ];
 
-function cleanOptions(options) {
-    return _.omitBy(options, value => _.isArray(value) && _.isEmpty(value));
-}
+/* Return object with pager and array of datasets.
 
+Fields: fields.fields or listFields
+
+Filters:
+
+    - filter.search: string
+    - attributeValues -> RVC_CREATED_BY_VACCINATION_APP === "true"
+    - Orgunits must be in user.dataViewOrganisationUnits.
+
+NOTE: It's not possible to filter all in a single call, so we first make an unpaginated call,
+filter the results, and finally build the pager ({page: number, total: number}) programatically.
+*/
 export async function list(config, d2, filters, pagination) {
-    const { search, showOnlyUserCampaigns } = filters || {};
-    const { page, pageSize = 20, sorting } = pagination || {};
+    const { search, fields: forcedFields } = filters || {};
+    const { page = 1, pageSize = 20, sorting } = pagination || {};
+
     // order=FIELD:DIRECTION where direction = "iasc" | "idesc" (insensitive ASC, DESC)
     const [field, direction] = sorting || [];
     const order = field && direction ? `${field}:i${direction}` : undefined;
-    const vaccinationIds = await getByAttribute(config, d2);
+
     const filter = _.compact([
         search ? `displayName:ilike:${search}` : null,
-        showOnlyUserCampaigns ? `user.id:eq:${d2.currentUser.id}` : null,
-        `id:in:[${vaccinationIds.join(",")}]`,
+        // Preliminar filter for attribute createdByApp (cannot check the value here)
+        `attributeValues.attribute.code:eq:${config.attributeCodeForApp}`,
     ]);
-    const listOptions = { fields, filter, page, pageSize, order };
-    const collection = await d2.models.dataSets.list(cleanOptions(listOptions));
-    return { pager: collection.pager, objects: collection.toArray() };
+    const fields = (forcedFields || defaultListFields).concat(requiredFields).join(",");
+    const listOptions = { fields, filter, pageSize: 1000, order };
+
+    const dataSetsBase = await d2.models.dataSets
+        .list(_.pickBy(listOptions, x => _.isNumber(x) || !_.isEmpty(x)))
+        .then(c => c.toArray());
+
+    const dataSetsFilterd = dataSetsBase.filter(
+        dataSet => isDataSetCreatedByApp(dataSet, config) && isDataSetInUserOrgUnits(d2, dataSet)
+    );
+
+    const dataSetsPaginated = _(dataSetsFilterd)
+        .drop(pageSize * (page - 1))
+        .take(pageSize)
+        .value();
+
+    return {
+        pager: { page, total: dataSetsFilterd.length },
+        objects: dataSetsPaginated,
+    };
 }
 
-async function getByAttribute(config, d2) {
-    const appCode = config.attributeCodeForApp;
-    const filter = `attributeValues.attribute.code:eq:${appCode}`;
-    const listOptions = {
-        filter,
-        fields: ["id", "attributeValues[value, attribute[code]]"],
-        paging: false,
-    };
-    const dataSets = await d2.models.dataSets.list(listOptions);
-    const ids = dataSets
-        .toArray()
-        .filter(
-            ({ attributeValues }) =>
-                !!attributeValues.some(
-                    ({ attribute, value }) =>
-                        attribute && attribute.code === appCode && value === "true"
-                )
-        )
-        .map(el => el.id);
-    return ids;
+function isDataSetCreatedByApp(dataSet, config) {
+    return dataSet.attributeValues.every(
+        attributeValue =>
+            attributeValue.attribute.code !== config.attributeCodeForApp ||
+            attributeValue.value === "true"
+    );
+}
+
+function isDataSetInUserOrgUnits(d2, dataSet) {
+    const userOrgUnits = getCurrentUserDataViewOrganisationUnits(d2);
+
+    return dataSet.organisationUnits.toArray().every(dataSetOrgUnit =>
+        _(dataSetOrgUnit.path.split("/"))
+            .intersection(userOrgUnits)
+            .isNotEmpty()
+    );
 }
 
 export async function getOrganisationUnitsById(id, d2) {

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -10,8 +10,6 @@ const defaultListFields = [
     "created",
     "lastUpdated",
     "publicAccess",
-    "userAccesses",
-    "userGroupAccesses",
     "user",
     "dataInputPeriods~paging=(1;1)",
     "href",

--- a/src/utils/lodash-mixins.ts
+++ b/src/utils/lodash-mixins.ts
@@ -7,6 +7,8 @@ declare module "lodash" {
             path: TKey | [TKey]
         ): TObject[TKey];
         cartesianProduct<T>(arr: T[][]): T[][];
+
+        isNotEmpty(value?: any): boolean;
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -14,6 +16,8 @@ declare module "lodash" {
             this: LoDashImplicitWrapper<TObject | null | undefined>,
             path: TKey | [TKey]
         ): TObject[TKey];
+
+        isNotEmpty(): boolean;
     }
 }
 
@@ -47,11 +51,10 @@ function getOrFail(obj: any, key: string | number): any {
     }
 }
 
+function isNotEmpty(obj: any): boolean {
+    return !_.isEmpty(obj);
+}
+
 _.mixin({ cartesianProduct });
 
-_.mixin(
-    {
-        getOrFail,
-    },
-    { chain: false }
-);
+_.mixin({ getOrFail, isNotEmpty }, { chain: false });


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #256

### :memo: Implementation

- All the infrastructure regarding *showOnlyUserCampaigns* has been removed.
- Refactored `datasets.list`. Previously, we were doing a double request to get only datasets created by the app, but this was bound to fail whenever the datasets grow and the URI gets to 8KB. Alternative: do the first request as restrictive as possible and do a second filter+pagination programmatically.
- Within the filter phase, we check the attribute createdByApp and also that all orgUnits of the dataset are contained in `currentUser.dataViewOrganisationUnits` (new filter).

Note: Now that we don't use the API pagination, we must be still more careful regarding the fields we request. I've removed some fields we were not actually using.

### :art: Screenshots

Example with `pageSize=2` (it's 20 in the app):

![image](https://user-images.githubusercontent.com/24643/62769258-dc941b80-ba98-11e9-9f4e-d2c33544dee0.png)
