### PR TITLE
Set expiry days to 8 and refactor data input periods

### DIFF
--- a/src/components/campaign-configuration/CampaignConfiguration.jsx
+++ b/src/components/campaign-configuration/CampaignConfiguration.jsx
@@ -6,7 +6,7 @@ import _ from "lodash";
 import Checkbox from "material-ui/Checkbox/Checkbox";
 
 import PageHeader from "../shared/PageHeader";
-import { list } from "../../models/datasets";
+import { list, getPeriodDatesFromDataSet } from "../../models/datasets";
 import { formatDateShort } from "../../utils/date";
 import Campaign from "../../models/campaign";
 import TargetPopulationDialog from "./TargetPopulationDialog";
@@ -165,23 +165,18 @@ class CampaignConfiguration extends React.Component {
     };
 
     getDateValue = (dateType, dataSet) => {
-        const dataInputPeriods = dataSet.dataInputPeriods;
-        let dateValue;
+        const periodDates = getPeriodDatesFromDataSet(dataSet);
+        if (!periodDates) return;
+
         switch (dateType) {
             case "startDate":
-                if (!_(dataInputPeriods).isEmpty()) {
-                    dateValue = formatDateShort(dataInputPeriods[0].openingDate);
-                }
-                break;
+                return formatDateShort(periodDates.startDate);
             case "endDate":
-                if (!_(dataInputPeriods).isEmpty()) {
-                    dateValue = formatDateShort(dataInputPeriods[0].closingDate);
-                }
-                break;
+                return formatDateShort(periodDates.endDate);
             default:
                 console.error(`Date type not supported: ${dateType}`);
+                return undefined;
         }
-        return dateValue;
     };
 
     onCreate = () => {

--- a/src/components/data-entry/DataEntry.jsx
+++ b/src/components/data-entry/DataEntry.jsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom";
 import moment from "moment";
 
 import PageHeader from "../shared/PageHeader";
-import { getOrganisationUnitsById, getDataInputPeriodsById } from "../../models/datasets";
+import { getOrganisationUnitsById, getPeriodDatesFromDataSetId } from "../../models/datasets";
 import { getDhis2Url } from "../../utils/routes";
 import { LinearProgress } from "@material-ui/core";
 import { withPageVisited } from "../utils/page-visited-app";
@@ -96,7 +96,7 @@ class DataEntry extends React.Component {
             iframe.contentWindow.dataSetSelected();
 
             // Remove non-valid periods
-            const dataInputPeriods = await getDataInputPeriodsById(dataSetId, d2);
+            const periodDates = await getPeriodDatesFromDataSetId(dataSetId, d2);
             const removeNonValidPeriods = () => {
                 const selectedDataSetId = iframeDocument.querySelector("#selectedDataSetId")
                     .selectedOptions[0].value;
@@ -107,9 +107,10 @@ class DataEntry extends React.Component {
                         const optionFormat = moment(option.value);
                         if (
                             optionFormat.isValid() &&
+                            periodDates &&
                             !optionFormat.isBetween(
-                                dataInputPeriods.openingDate,
-                                dataInputPeriods.closingDate,
+                                periodDates.startDate,
+                                periodDates.endDate,
                                 null,
                                 "[]"
                             )

--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -8,7 +8,7 @@ import Campaign from "./campaign";
 import { DataSetCustomForm } from "./DataSetCustomForm";
 import { Maybe, MetadataResponse, DataEntryForm, Section } from "./db.types";
 import { Metadata, DataSet, Response } from "./db.types";
-import { getDaysRange } from "../utils/date";
+import { getDaysRange, toISOStringNoTZ } from "../utils/date";
 import { getDataElements, CocMetadata } from "./AntigensDisaggregation";
 import { Dashboard, DashboardMetadata } from "./Dashboard";
 import { Teams, CategoryOptionTeam } from "./Teams";
@@ -108,8 +108,12 @@ export default class CampaignDb {
             categoryCombo: { id: dataElement.categoryCombo.id },
         }));
 
+        const closingDate = endDate.clone().add(metadataConfig.expirationDays, "days");
+
         const dataInputPeriods = getDaysRange(startDate, endDate).map(date => ({
             period: { id: date.format("YYYYMMDD") },
+            openingDate: toISOStringNoTZ(startDate),
+            closingDate: toISOStringNoTZ(closingDate),
         }));
 
         const existingDataSet = await this.getExistingDataSet();
@@ -130,7 +134,7 @@ export default class CampaignDb {
             dataSetElements,
             openFuturePeriods: 1,
             timelyDays: 0,
-            expiryDays: 8,
+            expiryDays: 0,
             formType: "CUSTOM",
             dataInputPeriods,
             attributeValues: [{ value: "true", attribute: { id: attributeForApp.id } }],

--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -8,7 +8,7 @@ import Campaign from "./campaign";
 import { DataSetCustomForm } from "./DataSetCustomForm";
 import { Maybe, MetadataResponse, DataEntryForm, Section } from "./db.types";
 import { Metadata, DataSet, Response } from "./db.types";
-import { getDaysRange, toISOStringNoTZ } from "../utils/date";
+import { getDaysRange } from "../utils/date";
 import { getDataElements, CocMetadata } from "./AntigensDisaggregation";
 import { Dashboard, DashboardMetadata } from "./Dashboard";
 import { Teams, CategoryOptionTeam } from "./Teams";
@@ -109,8 +109,6 @@ export default class CampaignDb {
         }));
 
         const dataInputPeriods = getDaysRange(startDate, endDate).map(date => ({
-            openingDate: toISOStringNoTZ(startDate),
-            closingDate: toISOStringNoTZ(endDate),
             period: { id: date.format("YYYYMMDD") },
         }));
 
@@ -132,7 +130,7 @@ export default class CampaignDb {
             dataSetElements,
             openFuturePeriods: 1,
             timelyDays: 0,
-            expiryDays: 0,
+            expiryDays: 8,
             formType: "CUSTOM",
             dataInputPeriods,
             attributeValues: [{ value: "true", attribute: { id: attributeForApp.id } }],

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -17,7 +17,7 @@ const expectedFields = [
     "user",
     "access",
     "attributeValues[value, attribute[code]]",
-    "dataInputPeriods~paging=(1;1)",
+    "dataInputPeriods[period[id]]",
     "href",
 ];
 

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -18,6 +18,7 @@ import {
 import { sortAgeGroups } from "../utils/age-groups";
 
 export const baseConfig = {
+    expirationDays: 8,
     categoryCodeForAntigens: "RVC_ANTIGEN",
     categoryCodeForAgeGroup: "RVC_AGE_GROUP",
     categoryCodeForDoses: "RVC_DOSE",

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import moment from "moment";
 
 const fields = [
     "id",
@@ -15,7 +16,7 @@ const fields = [
     "user",
     "access",
     "attributeValues[value, attribute[code]]",
-    "dataInputPeriods~paging=(1;1)",
+    "dataInputPeriods[period[id]]",
     "href",
 ];
 
@@ -70,11 +71,24 @@ export async function getOrganisationUnitsById(id, d2) {
     return _(organisationUnits).isEmpty() ? undefined : organisationUnits[0].id;
 }
 
-export async function getDataInputPeriodsById(id, d2) {
+export async function getPeriodDatesFromDataSetId(id, d2) {
     const fields = "dataInputPeriods";
     const dataSet = await d2.models.dataSets.get(id, { fields }).catch(() => undefined);
+    return dataSet ? getPeriodDatesFromDataSet(dataSet) : null;
+}
+
+export function getPeriodDatesFromDataSet(dataSet) {
     const dataInputPeriods = dataSet.dataInputPeriods;
-    return _(dataInputPeriods).isEmpty() ? undefined : dataInputPeriods[0];
+
+    if (_(dataInputPeriods).isEmpty()) {
+        return null;
+    } else {
+        const periodIdToDate = periodId => moment(periodId, "YYYYMMDD");
+        const periods = dataInputPeriods.map(dip => dip.period.id);
+        const startDate = periodIdToDate(_.min(periods));
+        const endDate = periodIdToDate(_.max(periods));
+        return { startDate, endDate };
+    }
 }
 
 export async function getDatasetById(id, d2) {

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -213,8 +213,8 @@ export interface DataEntryForm {
 }
 
 export interface DataInputPeriod {
-    openingDate: string;
-    closingDate: string;
+    openingDate?: string;
+    closingDate?: string;
     period: { id: string };
 }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #275

### :memo: Implementation

- `dataSet.expiryDays=8` means that a user can enter data for a day for 8 days after a specific date. So, if today is 20-08, and period selected for 13-08 -> OK, but 12-08 -> *Data Set is locked*.  [Relevant code](https://github.com/dhis2/dhis2-core/blob/2.30/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js#L1801). **NOTE:** If we want that a user can input data for any day in the campaign 8 days after the last day of the campaign, we should then set `expiryDays= 8 + numberOfDaysInCampaign`.
- Setting `dataSet.expiryDays=8` was trivial, but the `openingDate`/`closingDate` fields prevented it from working. Firstly, `closingDate` takes precedence over `expiryDays`. We could add 8 days to the closing date, but I also detected that the current 2.30 `form.js` code has parsing problems for these fields. A real example I came across with:

```
>> dhis2.de.dataSets[dhis2.de.currentDataSetId].dataInputPeriods
[
  {
    "period": {
      "periodType": "Daily",
      "startDate": "2019-08-12",
      "endDate": "2019-08-12",
      "isoPeriod": "20190812"
    },
    "openingDate": "Mon Aug 12 00:00:00 CEST 2019",
    "closingDate": "Mon Aug 12 00:00:00 CEST 2019"
  }
]

>> new Date("Mon Aug 12 00:00:00 CEST 2019")
Invalid Date
```

That would explain the erratic behaviour we usually experience with the closing logic. So I think the best course is to remove the open/closing dates altogether and rely solely on `dataInputPeriods[].period.id` and `expiryDays`. 

I've refactored the code that used those fields: 1) DataEntry, 2) CampaignConfigurator -> Details. Both work the same, just that now they check `dataInputPeriods[].period.id` instead of opening/closing dates.

- Docs (dev/user guide) updated.