### PR TITLE
Fix/catcombo names

### DIFF
--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -32,9 +32,7 @@ describe("Campaigns - Create", () => {
         cy.contains("Next").click();
 
         // Organisation Units Step
-        cy.contains(
-            "Select the health facilities or health area where the campaign will be implemented"
-        );
+        cy.contains("Select the health facilities");
 
         cy.get("[data-field='teams']").type(1);
 

--- a/cypress/integration/campaign-configurator/create.spec.js
+++ b/cypress/integration/campaign-configurator/create.spec.js
@@ -20,7 +20,7 @@ describe("Campaigns - Create", () => {
         // General Info step
         waitForStepChange("General info");
         cy.contains("Next").click();
-        cy.contains("Field name cannot be blank");
+        cy.contains("Field Name cannot be blank");
 
         cy.get("[data-field='name']").type("Test_vaccination_campaign_cypress");
         cy.contains("Start Date").click({ force: true });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vaccination-app",
     "description": "DHIS2 MSF Reactive Vaccination App",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -6,7 +6,7 @@ import _ from "lodash";
 import { withSnackbar, Wizard } from "d2-ui-components";
 import { LinearProgress } from "@material-ui/core";
 
-import Campaign from "models/campaign";
+import Campaign from "../../models/campaign";
 import PageHeader from "../shared/PageHeader";
 import OrganisationUnitsStep from "../steps/organisation-units/OrganisationUnitsStep";
 import SaveStep from "../steps/save/SaveStep";

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -1,7 +1,6 @@
 import { DataElement, Maybe, Ref } from "./db.types";
 import _ from "lodash";
 const fp = require("lodash/fp");
-import { AntigenDisaggregation } from "./AntigensDisaggregation";
 import { MetadataConfig, getCode } from "./config";
 import { Antigen } from "./campaign";
 import "../utils/lodash-mixins";

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -357,23 +357,19 @@ export class AntigensDisaggregation {
         ];
         const categoryOptionCombos = await db.getCocsByCategoryComboCode(allCategoryComboCodes);
 
-        /* Category option combos have the untranslated category Option names separated by commas */
-        const getTranslatedCocName: (cocName: string) => string = cocName => {
-            return cocName
-                .split(", ")
+        const getTranslatedCocName: (coNames: string[]) => string = coNames => {
+            return coNames
                 .map(coName => _(categoryOptionsDisplayNameByName).getOrFail(coName))
                 .join(", ");
         };
 
         const categoryOptionCombosIdByName = _(categoryOptionCombos)
-            .map(coc => [getTranslatedCocName(coc.name), coc.id])
+            .map(coc => [getTranslatedCocName(coc.categoryOptionNames), coc.id])
             .push(["", this.config.defaults.categoryOptionCombo.id])
             .fromPairs()
             .value();
 
-        return {
-            cocIdByName: categoryOptionCombosIdByName,
-        };
+        return { cocIdByName: categoryOptionCombosIdByName };
     }
 }
 

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -20,7 +20,6 @@ import {
     Response,
     DataValue,
     MetadataOptions,
-    NamedObject,
     Message,
 } from "./db.types";
 import "../utils/lodash-mixins";
@@ -308,17 +307,40 @@ export default class DbD2 {
         return categoryCombos;
     }
 
-    public async getCocsByCategoryComboCode(codes: string[]): Promise<NamedObject[]> {
-        const { categoryOptionCombos } = await this.getMetadata<{
-            categoryOptionCombos: NamedObject[];
+    public async getCocsByCategoryComboCode(
+        codes: string[]
+    ): Promise<Array<{ id: string; categoryOptionNames: string[] }>> {
+        const filter = `code:in:[${codes.join(",")}]`;
+
+        const { categoryOptionCombos, categoryCombos } = await this.getMetadata<{
+            categoryOptionCombos: Array<{
+                id: string;
+                categoryCombo: { id: string };
+                categoryOptions: Array<{ id: string }>;
+            }>;
+            categoryCombos: Array<{
+                id: string;
+                categories: Array<{ categoryOptions: Array<{ id: string; name: string }> }>;
+            }>;
         }>({
             categoryOptionCombos: {
-                fields: { id: true, name: true },
-                filters: [`categoryCombo.code:in:[${codes.join(",")}]`],
+                fields: {
+                    id: true,
+                    categoryCombo: { id: true },
+                    categoryOptions: { id: true },
+                },
+                filters: [`categoryCombo.${filter}`],
+            },
+            categoryCombos: {
+                fields: {
+                    id: true,
+                    categories: { categoryOptions: { id: true, name: true } },
+                },
+                filters: [filter],
             },
         });
 
-        return categoryOptionCombos;
+        return getCocsWithUntranslatedOptionNames(categoryCombos, categoryOptionCombos);
     }
 
     public async postMetadata<Metadata>(
@@ -468,6 +490,47 @@ export default class DbD2 {
 
         return response.dataValues || [];
     }
+}
+
+/* DHIS2 uses the locale of the user that generates a category option combo to set its
+   name (that's a bug, names should be untranslated), so we will use coc.categoryOptions instead.
+   Note that coc.categoryOptions does not keep the original categories order, so we need
+   the associated category combos to perform that sorting.
+*/
+
+function getCocsWithUntranslatedOptionNames(
+    categoryCombos: {
+        id: string;
+        categories: { categoryOptions: { id: string; name: string }[] }[];
+    }[],
+    categoryOptionCombos: {
+        id: string;
+        categoryCombo: { id: string };
+        categoryOptions: { id: string }[];
+    }[]
+) {
+    const categoryOptionNameById = _(categoryCombos)
+        .flatMap(categoryCombo => categoryCombo.categories)
+        .flatMap(category => category.categoryOptions)
+        .uniqBy(categoryOption => categoryOption.id)
+        .map(categoryOption => [categoryOption.id, categoryOption.name] as [string, string])
+        .fromPairs()
+        .value();
+
+    const categoryCombosById = _.keyBy(categoryCombos, categoryCombo => categoryCombo.id);
+
+    return categoryOptionCombos.map(coc => {
+        const categoryOptions = _.sortBy(coc.categoryOptions, categoryOption => {
+            const categoryCombo = _(categoryCombosById).getOrFail(coc.categoryCombo.id);
+            const categoryOptionIndex = _(categoryCombo.categories).findIndex(category =>
+                _(category.categoryOptions).some(co => co.id === categoryOption.id)
+            );
+            if (categoryOptionIndex < 0) throw new Error("Cannot find index of category option");
+            return categoryOptionIndex;
+        });
+        const names = categoryOptions.map(co => _(categoryOptionNameById).getOrFail(co.id));
+        return { id: coc.id, categoryOptionNames: names };
+    });
 }
 
 export function toStatusResponse(response: ApiResponse<MetadataResponse>): Response<string> {


### PR DESCRIPTION
Fixes problem: We were assuming coc.name always has an English name, but in fact it's generated with the locale of the user that imports the metadata (looks like a dhis2 bug)

### :memo: Implementation

- Get category option combos and category combos and use `coc.categoryOptions` (needs to be sorted by the order of the category in the category combo).

### :fire: Is there anything the reviewer should know to test it?

To test, you can delete a category combo, set a non-English locale and create the catCombo with same categories. This way, we will have cocs in different locales. Now create or edit a campaign using as locale English and then a non-English locale.

Tested locally and in dev.hmisocba.

Note: dev.hmisocba has a 2.30 build which the bug with attributeValues toggling, so on edit, you'll lose the createdBy attribute. Use maintenance to restore it.