### PR TITLE
Fix campaigs list for 2.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vaccination-app",
     "description": "DHIS2 MSF Reactive Vaccination App",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -17,7 +17,7 @@ const expectedFields = [
     "organisationUnits[id,path]",
 ];
 
-const createdByAppFilter = "attributeValues.attribute.code:eq:RVC_CREATED_BY_VACCINATION_APP";
+const createdByAppFilters = ["attributeValues.attribute.id:eq:1", "categoryCombo.code:eq:RVC_TEAM"];
 const emptyCollection = { pager: { page: 1, total: 0 }, toArray: () => [] };
 const listMock = jest.fn(() => Promise.resolve(emptyCollection));
 
@@ -31,7 +31,7 @@ describe("DataSets", () => {
                 expect(d2.models.dataSets.list).toHaveBeenCalledWith({
                     fields: expectedFields.join(","),
                     pageSize: 1000,
-                    filter: [createdByAppFilter],
+                    filter: createdByAppFilters,
                 });
             });
         });
@@ -55,7 +55,7 @@ describe("DataSets", () => {
                 expect(d2.models.dataSets.list).toHaveBeenCalledWith({
                     fields: expectedFields.join(","),
                     pageSize: 1000,
-                    filter: ["displayName:ilike:abc", createdByAppFilter],
+                    filter: ["displayName:ilike:abc", ...createdByAppFilters],
                     order: "displayName:idesc",
                 });
             });

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -7,7 +7,10 @@ import DbD2, { ApiResponse, toStatusResponse } from "./db-d2";
 import { AntigensDisaggregation, SectionForDisaggregation } from "./AntigensDisaggregation";
 import { MetadataConfig, getDashboardCode, getByIndex } from "./config";
 import { AntigenDisaggregationEnabled } from "./AntigensDisaggregation";
-import { TargetPopulation, TargetPopulationData } from "./TargetPopulation";
+import {
+    TargetPopulation,
+    TargetPopulationData as TargetPopulationData_,
+} from "./TargetPopulation";
 import CampaignDb from "./CampaignDb";
 import { promiseMap } from "../utils/promises";
 import i18n from "../locales";
@@ -15,7 +18,7 @@ import { TeamsMetadata, getTeamsForCampaign, filterTeamsByNames } from "./Teams"
 import CampaignSharing from "./CampaignSharing";
 import { CampaignNotification } from "./CampaignNotification";
 
-export type TargetPopulationData = TargetPopulationData;
+export type TargetPopulationData = TargetPopulationData_;
 
 export interface Antigen {
     id: string;

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -40,8 +40,9 @@ export async function list(config, d2, filters, pagination) {
 
     const filter = _.compact([
         search ? `displayName:ilike:${search}` : null,
-        // Preliminar filter for attribute createdByApp (cannot check the value here)
-        `attributeValues.attribute.code:eq:${config.attributeCodeForApp}`,
+        // Preliminar filters (presence of attribute createdByApp and categoryCombo=TEAMS)
+        `attributeValues.attribute.id:eq:${config.attributes.app.id}`,
+        `categoryCombo.code:eq:${config.categoryCodeForTeams}`,
     ]);
     const fields = (forcedFields || defaultListFields).concat(requiredFields).join(",");
     const listOptions = { fields, filter, pageSize: 1000, order };

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -1,7 +1,6 @@
 import moment from "moment";
 import _ from "lodash";
 
-import { AnalyticsResponse } from "./db-d2";
 import { D2, D2Api, DeleteResponse } from "./d2.types";
 import {
     OrganisationUnit,


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #304

### :memo: Implementation

As @tomassala pointed out, `filter=attributeValues.attribute.code:eq=CODE` does not work for 2.33. It looks indeed like an bug in the API.

However, we should not completely remove this filter. Even though there's a filter by attribute afterward, that base request now would have a very big response (1Mb, in my DB), since it gets all the unfiltered datasets. 

Solution: Used instead `filter=attributeValues.attributeid:eq=ID`, which works. Additionally, I've added an extra filter `categoryCombo=TEAMS`. This way the responses are now in the order of Kbs.

### :fire: Is there anything the reviewer should know to test it?

This should be tested in 2.30 and 2.33. The last db I had (HMISBckp_20200423_115159.sql.gz) has been upgraded to 2.33 and deployed to http://dev2.eyeseetea.com:8088/ (password: same than SP)