### PR TITLE
Convert charts/reportTables to new visualizations

### DIFF
--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -20,8 +20,7 @@ interface DataSetWithSections {
 }
 
 interface PostSaveMetadata {
-    charts: object[];
-    reportTables: object[];
+    visualizations: object[];
     dashboards: object[];
     dataSets: DataSet[];
     dataEntryForms: DataEntryForm[];
@@ -245,7 +244,7 @@ export default class CampaignDb {
         modelReferencesToDelete: ModelReference[]
     ): Promise<Response<string>> {
         const dashboardItems = _(modelReferencesToDelete)
-            .filter(o => _.includes(["charts", "reportTables"], o.model))
+            .filter(o => _.includes(["visualizations"], o.model))
             .value();
 
         return await db.deleteMany(dashboardItems);

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -15,15 +15,12 @@ import { MetadataConfig } from "./config";
 
 type DashboardItem = {
     type: string;
+    visualization: Ref;
 };
 
-export interface ChartItem extends DashboardItem {
-    chart: Ref;
-}
+export interface ChartItem extends DashboardItem {}
 
-export interface ReportTableItem extends DashboardItem {
-    reportTable: Ref;
-}
+export interface ReportTableItem extends DashboardItem {}
 
 type DashboardData = {
     id: string;
@@ -32,7 +29,7 @@ type DashboardData = {
     dashboardItems: Array<ReportTableItem | ChartItem>;
 };
 
-type allDashboardElements = {
+type AllDashboardElements = {
     charts: Array<object>;
     reportTables: Array<object>;
     items: Array<ChartItem | ReportTableItem>;
@@ -40,8 +37,7 @@ type allDashboardElements = {
 
 export type DashboardMetadata = {
     dashboards: DashboardData[];
-    charts: object[];
-    reportTables: object[];
+    visualizations: object[];
 };
 
 export class Dashboard {
@@ -186,7 +182,7 @@ export class Dashboard {
             sharing
         );
 
-        const keys: Array<keyof allDashboardElements> = ["items", "charts", "reportTables"];
+        const keys: Array<keyof AllDashboardElements> = ["items", "charts", "reportTables"];
         const { items, charts, reportTables } = _(keys)
             .map(key => [key, _(dashboardItems).getOrFail(key)])
             .fromPairs()
@@ -200,7 +196,9 @@ export class Dashboard {
             ...sharing,
         };
 
-        return { dashboards: [dashboard], charts, reportTables };
+        const visualizations = _.concat(charts, reportTables);
+
+        return { dashboards: [dashboard], visualizations };
     }
 
     createDashboardItems(
@@ -209,7 +207,7 @@ export class Dashboard {
         endDate: Moment,
         dashboardItemsMetadata: Dictionary<any>,
         sharing: Sharing
-    ): allDashboardElements {
+    ): AllDashboardElements {
         const { organisationUnitsWithName, legendMetadata } = dashboardItemsMetadata;
         const organisationUnitsMetadata = organisationUnitsWithName.map(
             (ou: OrganisationUnitWithName) => ({
@@ -251,13 +249,13 @@ export class Dashboard {
         const reportTableIds = reportTables.map(table => table.id);
 
         const dashboardCharts = chartIds.map((id: string) => ({
-            type: "CHART",
-            chart: { id },
+            type: "VISUALIZATION",
+            visualization: { id },
         }));
 
         const dashboardTables = reportTableIds.map((id: string) => ({
-            type: "REPORT_TABLE",
-            reportTable: { id },
+            type: "VISUALIZATION",
+            visualization: { id },
         }));
 
         const dashboardData = {

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -62,9 +62,7 @@ interface DashboardWithResources {
     name: string;
     dashboardItems: {
         id: string;
-        chart: Ref;
-        map: Ref;
-        reportTable: Ref;
+        visualization: Ref;
     };
 }
 
@@ -235,6 +233,7 @@ export default class Campaign {
         // It does work, however, if we delete the objects in this order:
         // 1) Dashboards, 2) Everything else except Category options 3) Category options (teams),
         const keys = ["dashboards", "other", "teams"];
+
         const referencesGroups = _(modelReferencesToDelete)
             .groupBy(({ model }) => {
                 if (model === "dashboards") {
@@ -266,6 +265,7 @@ export default class Campaign {
             .compact()
             .unzip()
             .value();
+
         const sendNotification = () => {
             const notification = new CampaignNotification(db);
             return notification.sendOnUpdateOrDelete(dataSetsWithDataValues, "delete");
@@ -633,9 +633,7 @@ export default class Campaign {
                     name: true,
                     dashboardItems: {
                         id: true,
-                        chart: { id: true },
-                        map: { id: true },
-                        reportTable: { id: true },
+                        visualization: { id: true },
                     },
                 },
                 filters: [`code:in:[${codes.join(",")}]`],
@@ -658,11 +656,7 @@ export default class Campaign {
 
         const resources: { model: string; id: string }[] = _(dashboards)
             .flatMap(dashboard => dashboard.dashboardItems)
-            .flatMap(item => [
-                { model: "charts", ref: item.chart },
-                { model: "reportTables", ref: item.reportTable },
-                { model: "maps", ref: item.map },
-            ])
+            .flatMap(item => [{ model: "visualizations", ref: item.visualization }])
             .map(({ model, ref }) => (ref ? { model, id: ref.id } : null))
             .compact()
             .value();

--- a/src/models/d2.types.ts
+++ b/src/models/d2.types.ts
@@ -20,6 +20,7 @@ export interface D2Api {
     get(url: string, data: Dictionary<any>): Promise<Dictionary<any>>;
     get<T>(url: string, data: Dictionary<any>): Promise<T>;
     post(url: string, data: Dictionary<any>): Promise<Dictionary<any>>;
+    update(url: string, data: Dictionary<any>): Promise<Dictionary<any>>;
     delete(url: string): Promise<DeleteResponse>;
     baseUrl: string;
 }

--- a/src/models/dashboard-items.js
+++ b/src/models/dashboard-items.js
@@ -530,8 +530,6 @@ const chartConstructor = ({
         _.isEmpty(disaggregations) ? null : "dx",
     ]);
 
-    const series = _.isEmpty(disaggregations) ? "dx" : columns[0].id;
-
     let organisationUnitElements;
     let organisationUnitNames;
 
@@ -580,8 +578,6 @@ const chartConstructor = ({
         percentStackedValues: false,
         noSpaceBetweenColumns: false,
         hideTitle: false,
-        series,
-        category: rows[0],
         access: {
             read: true,
             update: true,
@@ -653,6 +649,32 @@ const chartConstructor = ({
         categoryDimensions,
         filters: filterDimensions.map(fd => ({ id: fd })),
         rows: rows.map(r => ({ id: r })),
+        colSubTotals: false,
+        colTotals: false,
+        columnDimensions: columns.map(column => column.id),
+        digitGroupSeparator: "SPACE",
+        displayDensity: "NORMAL",
+        fixColumnHeaders: false,
+        fixRowHeaders: false,
+        fontSize: "NORMAL",
+        hideEmptyColumns: false,
+        hideEmptyRows: false,
+        legend: { showKey: false },
+        optionalAxes: [],
+        regression: false,
+        reportingParams: {
+            grandParentOrganisationUnit: false,
+            organisationUnit: false,
+            parentOrganisationUnit: false,
+            reportingPeriod: false,
+        },
+        rowDimensions: rows,
+        rowSubTotals: false,
+        rowTotals: false,
+        seriesKey: { hidden: false },
+        showDimensionLabels: false,
+        showHierarchy: false,
+        skipRounding: false,
     };
 };
 
@@ -737,6 +759,7 @@ const tableConstructor = ({
 
     return {
         id,
+        type: "PIVOT_TABLE",
         name: buildDashboardItemsCode(
             datasetName,
             organisationUnitNames,
@@ -746,7 +769,6 @@ const tableConstructor = ({
         ),
         numberType: "VALUE",
         userOrganisationUnitChildren: false,
-        legendDisplayStyle: "FILL",
         hideEmptyColumns: false,
         subscribed: false,
         hideEmptyRows: false,
@@ -774,21 +796,20 @@ const tableConstructor = ({
         //...getTitleWithTranslations(title, {}),
         ...getTitleWithTranslations(title, { period: periodForTitle }),
         externalAccess: false,
-        legendDisplayStrategy: "BY_DATA_ITEM", //FIXED
         colSubTotals: showColumnSubTotals,
         //legendSet: legendId ? { id: legendId } : null,
         showHierarchy: false,
         rowTotals: false,
-        cumulative: false,
+        cumulativeValues: false,
         digitGroupSeparator: "NONE",
         hideTitle: false,
         regression: false,
         skipRounding: false,
-        reportParams: {
-            paramGrandParentOrganisationUnit: false,
-            paramReportingPeriod: false,
-            paramOrganisationUnit: false,
-            paramParentOrganisationUnit: false,
+        reportingParams: {
+            grandParentOrganisationUnit: false,
+            organisationUnit: false,
+            parentOrganisationUnit: false,
+            reportingPeriod: false,
         },
         access: {
             read: true,
@@ -867,5 +888,19 @@ const tableConstructor = ({
         filters: allFilters,
         rows: rows.map(r => ({ id: r })),
         rowDimensions: rows,
+        fixColumnHeaders: false,
+        fixRowHeaders: false,
+        hideLegend: false,
+        legend: {
+            showKey: false,
+            strategy: "FIXED",
+            style: "FILL",
+        },
+        noSpaceBetweenColumns: false,
+        optionalAxes: [],
+        percentStackedValues: false,
+        seriesKey: { hidden: false },
+        showData: false,
+        yearlySeries: [],
     };
 };

--- a/src/models/dashboard-items.js
+++ b/src/models/dashboard-items.js
@@ -418,6 +418,7 @@ export function itemsMetadataConstructor(dashboardItemsMetadata) {
     };
 
     const tableElements = _(allTables)
+        .pickBy()
         .map((item, key) => [key, dataMapper(elementsMetadata, item.elements)])
         .fromPairs()
         .value();

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -155,8 +155,7 @@ export interface Metadata {
     dataSets?: Array<DataSet>;
     dataEntryForms?: Array<DataEntryForm>;
     sections?: Array<Section>;
-    charts?: Array<Dictionary<any>>;
-    reportTables?: Array<Dictionary<any>>;
+    visualizations?: Array<Dictionary<any>>;
     dashboards?: Array<Dictionary<any>>;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "noEmit": true,
         "strictNullChecks": true,
         "jsx": "preserve",
-        "noUnusedLocals": true
+        "noUnusedLocals": false
     },
     "include": ["src"]
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/2azzj13

### :memo: Implementation

- I diffed the JSON between charts/reportsTables in 2.33 with the same visualizations in 2.37 (automatically created by DHIS2 migrations) to check which fields were changed, added, or removed. With that, I refactored our generation code. Then, I compared visually the dashboard for a campaign in 2.33 to the same campaign in 2.37 to make sure all look the same.
- Note that, in 2.37, totals are not shown if there is only one row/column.
- Note that legends with colors are not applied, it was removed by Tomas at 1349350d

### :fire: Is there anything the reviewer should know to test it?

I used the campaign "RVC-VC test-Measles" with msfe-bikengevacc-mfp (I had to change the password and assign the orgunit: MSF -> OCC->VC -> Vaccination test.

Add population data and vaccination data so the dashboards have something to render.