### PR TITLE
Disaggregate campaigns by preventive/reactive type

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-23T10:31:50.107Z\n"
-"PO-Revision-Date: 2022-03-23T10:31:50.107Z\n"
+"POT-Creation-Date: 2022-07-15T10:33:36.402Z\n"
+"PO-Revision-Date: 2022-07-15T10:33:36.402Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -268,6 +268,9 @@ msgstr ""
 msgid "Field cannot be blank"
 msgstr ""
 
+msgid "Type"
+msgstr ""
+
 msgid "This user has no Data output and analytic organisation units assigned"
 msgstr ""
 
@@ -363,6 +366,12 @@ msgstr ""
 msgid ""
 "Campaign teams (category options) could not be deleted, probably there are "
 "associated data values"
+msgstr ""
+
+msgid "Reactive"
+msgstr ""
+
+msgid "Preventive"
 msgstr ""
 
 msgid "Coverage by Site {{- period}} (do not edit this chart)"

--- a/metadata/campaign-preventive-reactive-disaggregation.json
+++ b/metadata/campaign-preventive-reactive-disaggregation.json
@@ -1,0 +1,1137 @@
+{
+    "categories": [
+        {
+            "allItems": false,
+            "attributeValues": [],
+            "code": "RVC_PREVENTIVE_CAMPAIGN",
+            "created": "2022-07-15T08:40:45.060",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimension": false,
+            "dataDimensionType": "ATTRIBUTE",
+            "dimension": "hiZHZ3Nqt8f",
+            "dimensionType": "CATEGORY",
+            "displayFormName": "Preventive Campaign",
+            "displayName": "Preventive Campaign",
+            "displayShortName": "Preventive Campaign",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "hiZHZ3Nqt8f",
+            "items": [
+                {
+                    "id": "p5Sd5DIKYHy"
+                }
+            ],
+            "lastUpdated": "2022-07-18T10:52:03.298",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Preventive Campaign",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "Preventive Campaign",
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "allItems": false,
+            "attributeValues": [],
+            "code": "RVC_REACTIVE_CAMPAIGN",
+            "created": "2022-07-15T08:41:04.095",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimension": false,
+            "dataDimensionType": "ATTRIBUTE",
+            "dimension": "ABCiCnIufIF",
+            "dimensionType": "CATEGORY",
+            "displayFormName": "Reactive Campaign",
+            "displayName": "Reactive Campaign",
+            "displayShortName": "Reactive Campaign",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "ABCiCnIufIF",
+            "items": [
+                {
+                    "id": "IhLAod6GvkU"
+                }
+            ],
+            "lastUpdated": "2022-07-18T10:52:03.298",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Reactive Campaign",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "Reactive Campaign",
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "allItems": false,
+            "attributeValues": [],
+            "code": "RVC_CAMPAIGN_TYPE",
+            "created": "2022-07-15T08:43:00.137",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimension": true,
+            "dataDimensionType": "ATTRIBUTE",
+            "dimension": "J66G0eA8MGR",
+            "dimensionType": "CATEGORY",
+            "displayFormName": "_23.7 RVC Campaign",
+            "displayName": "_23.7 RVC Campaign",
+            "displayShortName": "_23.7 RVC Campaign",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "J66G0eA8MGR",
+            "items": [
+                {
+                    "id": "p5Sd5DIKYHy"
+                },
+                {
+                    "id": "IhLAod6GvkU"
+                }
+            ],
+            "lastUpdated": "2022-07-18T10:52:03.298",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "_23.7 RVC Campaign",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "_23.7 RVC Campaign",
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        }
+    ],
+    "categoryCombos": [
+        {
+            "attributeValues": [],
+            "code": "RVC_PREVENTIVE",
+            "created": "2022-07-18T10:22:58.623",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimensionType": "ATTRIBUTE",
+            "displayName": "Preventive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "nYyO6QGI9WN",
+            "isDefault": false,
+            "lastUpdated": "2022-07-18T10:52:03.306",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Preventive",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "skipTotal": false,
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "attributeValues": [],
+            "code": "RVC_REACTIVE",
+            "created": "2022-07-18T10:23:16.193",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimensionType": "ATTRIBUTE",
+            "displayName": "Reactive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "bhj5vhgcm8E",
+            "isDefault": false,
+            "lastUpdated": "2022-07-18T10:52:03.306",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Reactive",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "skipTotal": false,
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "attributeValues": [],
+            "code": "RVC_TEAM_PREVENTIVE",
+            "created": "2022-07-15T08:43:35.430",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimensionType": "ATTRIBUTE",
+            "displayName": "Team / Preventive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "uxkKXEwurKu",
+            "isDefault": false,
+            "lastUpdated": "2022-07-18T10:52:03.306",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Team / Preventive",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "skipTotal": false,
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "attributeValues": [],
+            "code": "RVC_TEAM_REACTIVE",
+            "created": "2022-07-15T08:43:47.830",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimensionType": "ATTRIBUTE",
+            "displayName": "Team / Reactive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "yVdUAuXp8Ly",
+            "isDefault": false,
+            "lastUpdated": "2022-07-18T10:52:03.306",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Team / Reactive",
+            "publicAccess": "rw------",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "skipTotal": false,
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        }
+    ],
+    "categoryOptionCombos": [
+        {
+            "created": "2022-07-18T10:22:58.662",
+            "dimensionItem": "z5ONfWrqp6b",
+            "displayFormName": "Preventive",
+            "displayName": "Preventive",
+            "displayShortName": "Preventive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "z5ONfWrqp6b",
+            "ignoreApproval": false,
+            "lastUpdated": "2022-07-18T10:52:03.313",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "legendSets": [],
+            "name": "Preventive",
+            "periodOffset": 0,
+            "sharing": {
+                "external": false,
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "Preventive",
+            "translations": [],
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "created": "2022-07-18T10:23:16.216",
+            "dimensionItem": "CjUzGG0Q01j",
+            "displayFormName": "Reactive",
+            "displayName": "Reactive",
+            "displayShortName": "Reactive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "CjUzGG0Q01j",
+            "ignoreApproval": false,
+            "lastUpdated": "2022-07-18T10:52:03.313",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "legendSets": [],
+            "name": "Reactive",
+            "periodOffset": 0,
+            "sharing": {
+                "external": false,
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "Reactive",
+            "translations": [],
+            "userAccesses": [],
+            "userGroupAccesses": []
+        }
+    ],
+    "categoryOptions": [
+        {
+            "attributeValues": [],
+            "categoryOptionCombos": [
+                {
+                    "id": "z5ONfWrqp6b"
+                },
+                {
+                    "id": "LqfxjR4ecz9"
+                },
+                {
+                    "id": "CLs8u2AW4r0"
+                },
+                {
+                    "id": "kzm5l6ZcDGT"
+                },
+                {
+                    "id": "NUi2EJ87vRU"
+                },
+                {
+                    "id": "XKXgoZRFKTQ"
+                },
+                {
+                    "id": "h1gIYT50vpI"
+                },
+                {
+                    "id": "BgWoyXE50ni"
+                },
+                {
+                    "id": "PPwi5nDp2zp"
+                },
+                {
+                    "id": "CD5jWoPebq8"
+                },
+                {
+                    "id": "ia4R1auQs0i"
+                },
+                {
+                    "id": "SCRsNtccKzS"
+                },
+                {
+                    "id": "c6mwqYpaPJt"
+                },
+                {
+                    "id": "MsbCpaXETUK"
+                },
+                {
+                    "id": "QUtJmVRa3Gj"
+                },
+                {
+                    "id": "YsFRsZIK5bS"
+                },
+                {
+                    "id": "mZh4AiB2Opo"
+                },
+                {
+                    "id": "zdRI34TWG65"
+                },
+                {
+                    "id": "dojFaCY7TBr"
+                },
+                {
+                    "id": "a8eQhWlrU2l"
+                },
+                {
+                    "id": "TwrCeGW47fZ"
+                },
+                {
+                    "id": "OJz7dUErOmv"
+                },
+                {
+                    "id": "kqQBBqpIbv2"
+                },
+                {
+                    "id": "CK8odP6J4Ue"
+                },
+                {
+                    "id": "YZuKcQFMERt"
+                },
+                {
+                    "id": "V0T1AtjbQYg"
+                },
+                {
+                    "id": "YcoxTv1DjXr"
+                },
+                {
+                    "id": "RF6Ua7BoXCC"
+                },
+                {
+                    "id": "IpeRHEuI2kM"
+                },
+                {
+                    "id": "X0557d1NQZu"
+                },
+                {
+                    "id": "KGlezBkVsEa"
+                },
+                {
+                    "id": "FOpGSN4FGZf"
+                },
+                {
+                    "id": "ubORMXHLIgc"
+                },
+                {
+                    "id": "F8VhiqZLL70"
+                },
+                {
+                    "id": "h1Jp25YCZfo"
+                },
+                {
+                    "id": "X5oVLABwvmO"
+                },
+                {
+                    "id": "DsiLmkGNOJD"
+                },
+                {
+                    "id": "k5hQn1He0bh"
+                },
+                {
+                    "id": "nF0aWtk9V4t"
+                },
+                {
+                    "id": "TwqxUWZl2gs"
+                },
+                {
+                    "id": "VS6plyrzfjz"
+                },
+                {
+                    "id": "zxWNllbVlwh"
+                },
+                {
+                    "id": "D0IjWRP1JjW"
+                },
+                {
+                    "id": "SgcKXgnac6H"
+                },
+                {
+                    "id": "PQdbfvD7l86"
+                },
+                {
+                    "id": "OrMrc07soqV"
+                },
+                {
+                    "id": "UQxGiZZbBid"
+                },
+                {
+                    "id": "vzu9spDJnOT"
+                },
+                {
+                    "id": "nXw4esiSZ6E"
+                },
+                {
+                    "id": "YxEjiBOzodp"
+                },
+                {
+                    "id": "gtKZ76nPqwU"
+                },
+                {
+                    "id": "NQL78EWZi0M"
+                },
+                {
+                    "id": "clPOHHqARC9"
+                },
+                {
+                    "id": "MJEc5GM9ebZ"
+                },
+                {
+                    "id": "x5Ll3MU3Pmv"
+                },
+                {
+                    "id": "BC9jIo6nXYK"
+                },
+                {
+                    "id": "FffDhySAnjk"
+                },
+                {
+                    "id": "ahxc8hezY2h"
+                },
+                {
+                    "id": "hNMccgHkdhW"
+                },
+                {
+                    "id": "Jk3e3qiO8sH"
+                },
+                {
+                    "id": "OUKBHfAPiuC"
+                },
+                {
+                    "id": "nCXZbLoaroS"
+                },
+                {
+                    "id": "WPx6ZgACaLq"
+                },
+                {
+                    "id": "RgHq78WUoHk"
+                },
+                {
+                    "id": "YHfbPgbEM9M"
+                },
+                {
+                    "id": "ogfoKkPDDCS"
+                },
+                {
+                    "id": "YZ6BYJ8TrZ9"
+                },
+                {
+                    "id": "lpTMeJOWCa7"
+                },
+                {
+                    "id": "VFT6qg8b2Yg"
+                },
+                {
+                    "id": "S3DXWIBIxrb"
+                },
+                {
+                    "id": "j59X0Wd7paT"
+                },
+                {
+                    "id": "l0Sts0o2bdB"
+                },
+                {
+                    "id": "TPXu4bLe2AW"
+                },
+                {
+                    "id": "L673BMO61rf"
+                },
+                {
+                    "id": "wj8403zfOOq"
+                },
+                {
+                    "id": "zklDL6kePpe"
+                },
+                {
+                    "id": "hUPhgTuHSI0"
+                },
+                {
+                    "id": "HPMpGczr0U4"
+                },
+                {
+                    "id": "zQ7GWrrL9Gr"
+                },
+                {
+                    "id": "DpqkjhtdwaC"
+                },
+                {
+                    "id": "TMWYhy2MmFl"
+                },
+                {
+                    "id": "Du31CSrLIXD"
+                },
+                {
+                    "id": "DXbgdnt3WtG"
+                },
+                {
+                    "id": "ouSoMu1qG3u"
+                },
+                {
+                    "id": "INxUusEpgw0"
+                },
+                {
+                    "id": "pk1O7fmoupI"
+                },
+                {
+                    "id": "MWAMwf12VlV"
+                },
+                {
+                    "id": "RAiPr6OYCyQ"
+                },
+                {
+                    "id": "l0OjU6cmfAp"
+                },
+                {
+                    "id": "agBsUMhmo8H"
+                },
+                {
+                    "id": "eKZR1hSgPG1"
+                },
+                {
+                    "id": "Oq31kQzdpN4"
+                },
+                {
+                    "id": "sUmJ9C2JzPL"
+                },
+                {
+                    "id": "w1AiCjvwqfn"
+                },
+                {
+                    "id": "GOzDa6Ndrra"
+                },
+                {
+                    "id": "y2U8KBjEYUz"
+                },
+                {
+                    "id": "qgHs1NmBz9X"
+                },
+                {
+                    "id": "QxEKmYKd9d7"
+                },
+                {
+                    "id": "grzjvra3sji"
+                },
+                {
+                    "id": "gRBYiMSXRbS"
+                },
+                {
+                    "id": "t4SRAOe4VFs"
+                },
+                {
+                    "id": "EuDT0ywuT1Q"
+                },
+                {
+                    "id": "oMcwQxe9egp"
+                },
+                {
+                    "id": "Q9b8KeEGh6r"
+                }
+            ],
+            "code": "RVC_PREVENTIVE",
+            "created": "2022-07-15T08:39:58.813",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dimensionItem": "p5Sd5DIKYHy",
+            "dimensionItemType": "CATEGORY_OPTION",
+            "displayFormName": "Preventive",
+            "displayName": "Preventive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "p5Sd5DIKYHy",
+            "isDefault": false,
+            "lastUpdated": "2022-07-18T10:52:03.287",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "legendSets": [],
+            "name": "Preventive",
+            "organisationUnits": [],
+            "periodOffset": 0,
+            "publicAccess": "rwrw----",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rwrw----",
+                "userGroups": {},
+                "users": {}
+            },
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        },
+        {
+            "attributeValues": [],
+            "categoryOptionCombos": [
+                {
+                    "id": "Z71VUCLq6px"
+                },
+                {
+                    "id": "p1A4X8Wrjpo"
+                },
+                {
+                    "id": "yZH1z8prDVZ"
+                },
+                {
+                    "id": "hzRgsMBe9mj"
+                },
+                {
+                    "id": "QljiNRsyvuG"
+                },
+                {
+                    "id": "fceyA8t6oT8"
+                },
+                {
+                    "id": "s8YmqOllqJZ"
+                },
+                {
+                    "id": "UAJ1JnLjt1a"
+                },
+                {
+                    "id": "XYATw8rpqnf"
+                },
+                {
+                    "id": "Hx0ridkJ1MN"
+                },
+                {
+                    "id": "P1kcNNDqU2Q"
+                },
+                {
+                    "id": "m1DpaMSy8f6"
+                },
+                {
+                    "id": "iKzcLBksTBN"
+                },
+                {
+                    "id": "z81H86NSCwq"
+                },
+                {
+                    "id": "qTpBStzsQpn"
+                },
+                {
+                    "id": "xvlI8CIjKbN"
+                },
+                {
+                    "id": "MD4X2yqUH1q"
+                },
+                {
+                    "id": "EPVqzCZTg7a"
+                },
+                {
+                    "id": "G61tcVneIXJ"
+                },
+                {
+                    "id": "bWRuiIXSbAO"
+                },
+                {
+                    "id": "tTPlK93HY0L"
+                },
+                {
+                    "id": "k5rSduXudwk"
+                },
+                {
+                    "id": "ZPGNXxrI91x"
+                },
+                {
+                    "id": "GKfwcQscEZv"
+                },
+                {
+                    "id": "cSJYD8cA2HK"
+                },
+                {
+                    "id": "PK6zZ5CQnk5"
+                },
+                {
+                    "id": "yhHv0ag4J7h"
+                },
+                {
+                    "id": "Mcrlpq1aTTk"
+                },
+                {
+                    "id": "ADRyCcGqM7T"
+                },
+                {
+                    "id": "XVCSKEknbGp"
+                },
+                {
+                    "id": "XCo1lRdcU0Q"
+                },
+                {
+                    "id": "svbhLIfmbpT"
+                },
+                {
+                    "id": "AQxtA4ioqbD"
+                },
+                {
+                    "id": "JuTI7osAcnZ"
+                },
+                {
+                    "id": "RT9JGVuoc71"
+                },
+                {
+                    "id": "OX8TlKPMLI0"
+                },
+                {
+                    "id": "HH8vlzq1uKf"
+                },
+                {
+                    "id": "YZBi1G2yJ25"
+                },
+                {
+                    "id": "WOcfCwXVXgb"
+                },
+                {
+                    "id": "Ph0QN5acqsR"
+                },
+                {
+                    "id": "Eyzc7alLSHA"
+                },
+                {
+                    "id": "fePcr7nSAd6"
+                },
+                {
+                    "id": "twO1ZZt25wV"
+                },
+                {
+                    "id": "cSJ1gRiWrde"
+                },
+                {
+                    "id": "aok82tv9ciz"
+                },
+                {
+                    "id": "d9l5UvrOKqw"
+                },
+                {
+                    "id": "uvVCdPmcXfq"
+                },
+                {
+                    "id": "lPAOoZKRUNt"
+                },
+                {
+                    "id": "Gi65PoT0gGN"
+                },
+                {
+                    "id": "H0yRbZpCOaK"
+                },
+                {
+                    "id": "yuevFAX8JPy"
+                },
+                {
+                    "id": "YzLVqOHbDfr"
+                },
+                {
+                    "id": "YBtgVLvQw3q"
+                },
+                {
+                    "id": "KAe6MTtj8SK"
+                },
+                {
+                    "id": "x8Td55DQ6fc"
+                },
+                {
+                    "id": "PoAC4cDCTAJ"
+                },
+                {
+                    "id": "SvqczA24EBF"
+                },
+                {
+                    "id": "rOjueLPNlxk"
+                },
+                {
+                    "id": "DDxQPI7rkqc"
+                },
+                {
+                    "id": "i6LX8Wv6UBG"
+                },
+                {
+                    "id": "zI6xP1nLiGG"
+                },
+                {
+                    "id": "lgJ4m5dWs2R"
+                },
+                {
+                    "id": "ZRvpY7N2t1G"
+                },
+                {
+                    "id": "qf98ppDGxwB"
+                },
+                {
+                    "id": "UiPbSpsOAfC"
+                },
+                {
+                    "id": "rFfEX144NmR"
+                },
+                {
+                    "id": "phu8leew1vW"
+                },
+                {
+                    "id": "iRG6J5hh0lA"
+                },
+                {
+                    "id": "wzgwXCBh9LH"
+                },
+                {
+                    "id": "NJvvbYUXfuB"
+                },
+                {
+                    "id": "ESYXKpgsH3b"
+                },
+                {
+                    "id": "qqMaIsUIEW4"
+                },
+                {
+                    "id": "j6bqbtRz6Af"
+                },
+                {
+                    "id": "iDo77qMSVci"
+                },
+                {
+                    "id": "VgAsxyq7krg"
+                },
+                {
+                    "id": "bnv4qGJGiP6"
+                },
+                {
+                    "id": "xznRg2ms62A"
+                },
+                {
+                    "id": "nqKhN1DKRpN"
+                },
+                {
+                    "id": "JkZYMYcsNsT"
+                },
+                {
+                    "id": "TPlvf9AxxtQ"
+                },
+                {
+                    "id": "bbGqalcImkm"
+                },
+                {
+                    "id": "I3VLgKRy4Iz"
+                },
+                {
+                    "id": "o6QeVqZ9LZT"
+                },
+                {
+                    "id": "ZUf1SDndcYD"
+                },
+                {
+                    "id": "h5CDE28IKfy"
+                },
+                {
+                    "id": "m0qcAyddGWb"
+                },
+                {
+                    "id": "Z3GjwqGO9K8"
+                },
+                {
+                    "id": "zY3k8woQqRJ"
+                },
+                {
+                    "id": "V5ITTM9jIK3"
+                },
+                {
+                    "id": "KQ4DDJS94WM"
+                },
+                {
+                    "id": "U8OjammT44m"
+                },
+                {
+                    "id": "cRltFoURpHo"
+                },
+                {
+                    "id": "WcIB9o8QKz8"
+                },
+                {
+                    "id": "u600juThIE1"
+                },
+                {
+                    "id": "iGFIv5MHhrd"
+                },
+                {
+                    "id": "xycwJg6wsln"
+                },
+                {
+                    "id": "aTdpePCIMXt"
+                },
+                {
+                    "id": "wRBF7LCCUvU"
+                },
+                {
+                    "id": "CjUzGG0Q01j"
+                },
+                {
+                    "id": "f93OUrettAp"
+                },
+                {
+                    "id": "vLPO8a7XeBn"
+                },
+                {
+                    "id": "Z5bY612ORYd"
+                },
+                {
+                    "id": "FnxbyefbiCY"
+                },
+                {
+                    "id": "qjF3IYvX9Fm"
+                }
+            ],
+            "code": "RVC_REACTIVE",
+            "created": "2022-07-15T08:39:53.295",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dimensionItem": "IhLAod6GvkU",
+            "dimensionItemType": "CATEGORY_OPTION",
+            "displayFormName": "Reactive",
+            "displayName": "Reactive",
+            "externalAccess": false,
+            "favorite": false,
+            "favorites": [],
+            "id": "IhLAod6GvkU",
+            "isDefault": false,
+            "lastUpdated": "2022-07-18T10:52:03.287",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "legendSets": [],
+            "name": "Reactive",
+            "organisationUnits": [],
+            "periodOffset": 0,
+            "publicAccess": "rwrw----",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rwrw----",
+                "userGroups": {},
+                "users": {}
+            },
+            "translations": [],
+            "user": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "userAccesses": [],
+            "userGroupAccesses": []
+        }
+    ]
+}

--- a/metadata/campaign-preventive-reactive-disaggregation.json
+++ b/metadata/campaign-preventive-reactive-disaggregation.json
@@ -1,116 +1,15 @@
 {
     "categories": [
         {
-            "allItems": false,
             "attributeValues": [],
-            "code": "RVC_PREVENTIVE_CAMPAIGN",
-            "created": "2022-07-15T08:40:45.060",
-            "createdBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "dataDimension": false,
-            "dataDimensionType": "ATTRIBUTE",
-            "dimension": "hiZHZ3Nqt8f",
-            "dimensionType": "CATEGORY",
-            "displayFormName": "Preventive Campaign",
-            "displayName": "Preventive Campaign",
-            "displayShortName": "Preventive Campaign",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "hiZHZ3Nqt8f",
-            "items": [
+            "categoryOptions": [
+                {
+                    "id": "IhLAod6GvkU"
+                },
                 {
                     "id": "p5Sd5DIKYHy"
                 }
             ],
-            "lastUpdated": "2022-07-18T10:52:03.298",
-            "lastUpdatedBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "name": "Preventive Campaign",
-            "publicAccess": "rw------",
-            "sharing": {
-                "external": false,
-                "owner": "Q7lEw9NnaKS",
-                "public": "rw------",
-                "userGroups": {},
-                "users": {}
-            },
-            "shortName": "Preventive Campaign",
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
-        },
-        {
-            "allItems": false,
-            "attributeValues": [],
-            "code": "RVC_REACTIVE_CAMPAIGN",
-            "created": "2022-07-15T08:41:04.095",
-            "createdBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "dataDimension": false,
-            "dataDimensionType": "ATTRIBUTE",
-            "dimension": "ABCiCnIufIF",
-            "dimensionType": "CATEGORY",
-            "displayFormName": "Reactive Campaign",
-            "displayName": "Reactive Campaign",
-            "displayShortName": "Reactive Campaign",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "ABCiCnIufIF",
-            "items": [
-                {
-                    "id": "IhLAod6GvkU"
-                }
-            ],
-            "lastUpdated": "2022-07-18T10:52:03.298",
-            "lastUpdatedBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "name": "Reactive Campaign",
-            "publicAccess": "rw------",
-            "sharing": {
-                "external": false,
-                "owner": "Q7lEw9NnaKS",
-                "public": "rw------",
-                "userGroups": {},
-                "users": {}
-            },
-            "shortName": "Reactive Campaign",
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
-        },
-        {
-            "allItems": false,
-            "attributeValues": [],
             "code": "RVC_CAMPAIGN_TYPE",
             "created": "2022-07-15T08:43:00.137",
             "createdBy": {
@@ -121,24 +20,8 @@
             },
             "dataDimension": true,
             "dataDimensionType": "ATTRIBUTE",
-            "dimension": "J66G0eA8MGR",
-            "dimensionType": "CATEGORY",
-            "displayFormName": "_23.7 RVC Campaign",
-            "displayName": "_23.7 RVC Campaign",
-            "displayShortName": "_23.7 RVC Campaign",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
             "id": "J66G0eA8MGR",
-            "items": [
-                {
-                    "id": "p5Sd5DIKYHy"
-                },
-                {
-                    "id": "IhLAod6GvkU"
-                }
-            ],
-            "lastUpdated": "2022-07-18T10:52:03.298",
+            "lastUpdated": "2022-07-20T13:54:17.125",
             "lastUpdatedBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
@@ -146,7 +29,6 @@
                 "username": "admin"
             },
             "name": "_23.7 RVC Campaign",
-            "publicAccess": "rw------",
             "sharing": {
                 "external": false,
                 "owner": "Q7lEw9NnaKS",
@@ -155,22 +37,90 @@
                 "users": {}
             },
             "shortName": "_23.7 RVC Campaign",
-            "translations": [],
-            "user": {
+            "translations": []
+        },
+        {
+            "attributeValues": [],
+            "categoryOptions": [
+                {
+                    "id": "p5Sd5DIKYHy"
+                }
+            ],
+            "code": "RVC_PREVENTIVE_CAMPAIGN",
+            "created": "2022-07-25T13:09:22.579",
+            "createdBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
                 "name": "admin admin",
                 "username": "admin"
             },
-            "userAccesses": [],
-            "userGroupAccesses": []
+            "dataDimension": true,
+            "dataDimensionType": "ATTRIBUTE",
+            "id": "MTEu71IXuif",
+            "lastUpdated": "2022-07-25T13:09:22.579",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Preventive campaign",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "Preventive campaign",
+            "translations": []
+        },
+        {
+            "attributeValues": [],
+            "categoryOptions": [
+                {
+                    "id": "IhLAod6GvkU"
+                }
+            ],
+            "code": "RVC_REACTIVE_CAMPAIGN",
+            "created": "2022-07-25T13:09:46.145",
+            "createdBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "dataDimension": true,
+            "dataDimensionType": "ATTRIBUTE",
+            "id": "SU8rtLKRTn0",
+            "lastUpdated": "2022-07-25T13:09:46.145",
+            "lastUpdatedBy": {
+                "displayName": "admin admin",
+                "id": "Q7lEw9NnaKS",
+                "name": "admin admin",
+                "username": "admin"
+            },
+            "name": "Reactive Campaign",
+            "sharing": {
+                "external": false,
+                "owner": "Q7lEw9NnaKS",
+                "public": "rw------",
+                "userGroups": {},
+                "users": {}
+            },
+            "shortName": "Reactive Campaign",
+            "translations": []
         }
     ],
     "categoryCombos": [
         {
-            "attributeValues": [],
-            "code": "RVC_PREVENTIVE",
-            "created": "2022-07-18T10:22:58.623",
+            "categories": [
+                {
+                    "id": "J66G0eA8MGR"
+                }
+            ],
+            "code": "RVC_CAMPAIGN_TYPE",
+            "created": "2022-07-20T13:54:57.517",
             "createdBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
@@ -178,21 +128,15 @@
                 "username": "admin"
             },
             "dataDimensionType": "ATTRIBUTE",
-            "displayName": "Preventive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "nYyO6QGI9WN",
-            "isDefault": false,
-            "lastUpdated": "2022-07-18T10:52:03.306",
+            "id": "e6tYJqVKrLL",
+            "lastUpdated": "2022-07-20T13:55:13.392",
             "lastUpdatedBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
                 "name": "admin admin",
                 "username": "admin"
             },
-            "name": "Preventive",
-            "publicAccess": "rw------",
+            "name": "Campaign Type",
             "sharing": {
                 "external": false,
                 "owner": "Q7lEw9NnaKS",
@@ -201,64 +145,19 @@
                 "users": {}
             },
             "skipTotal": false,
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
+            "translations": []
         },
         {
-            "attributeValues": [],
-            "code": "RVC_REACTIVE",
-            "created": "2022-07-18T10:23:16.193",
-            "createdBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "dataDimensionType": "ATTRIBUTE",
-            "displayName": "Reactive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "bhj5vhgcm8E",
-            "isDefault": false,
-            "lastUpdated": "2022-07-18T10:52:03.306",
-            "lastUpdatedBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "name": "Reactive",
-            "publicAccess": "rw------",
-            "sharing": {
-                "external": false,
-                "owner": "Q7lEw9NnaKS",
-                "public": "rw------",
-                "userGroups": {},
-                "users": {}
-            },
-            "skipTotal": false,
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
-        },
-        {
-            "attributeValues": [],
+            "categories": [
+                {
+                    "id": "qCY7FfAFlPl"
+                },
+                {
+                    "id": "MTEu71IXuif"
+                }
+            ],
             "code": "RVC_TEAM_PREVENTIVE",
-            "created": "2022-07-15T08:43:35.430",
+            "created": "2022-07-22T15:19:53.857",
             "createdBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
@@ -266,13 +165,8 @@
                 "username": "admin"
             },
             "dataDimensionType": "ATTRIBUTE",
-            "displayName": "Team / Preventive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "uxkKXEwurKu",
-            "isDefault": false,
-            "lastUpdated": "2022-07-18T10:52:03.306",
+            "id": "ZvVkJTqHjAD",
+            "lastUpdated": "2022-07-22T15:33:58.580",
             "lastUpdatedBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
@@ -280,7 +174,6 @@
                 "username": "admin"
             },
             "name": "Team / Preventive",
-            "publicAccess": "rw------",
             "sharing": {
                 "external": false,
                 "owner": "Q7lEw9NnaKS",
@@ -289,18 +182,17 @@
                 "users": {}
             },
             "skipTotal": false,
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
+            "translations": []
         },
         {
-            "attributeValues": [],
+            "categories": [
+                {
+                    "id": "qCY7FfAFlPl"
+                },
+                {
+                    "id": "SU8rtLKRTn0"
+                }
+            ],
             "code": "RVC_TEAM_REACTIVE",
             "created": "2022-07-15T08:43:47.830",
             "createdBy": {
@@ -310,13 +202,8 @@
                 "username": "admin"
             },
             "dataDimensionType": "ATTRIBUTE",
-            "displayName": "Team / Reactive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
             "id": "yVdUAuXp8Ly",
-            "isDefault": false,
-            "lastUpdated": "2022-07-18T10:52:03.306",
+            "lastUpdated": "2022-07-22T15:33:53.687",
             "lastUpdatedBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
@@ -324,7 +211,6 @@
                 "username": "admin"
             },
             "name": "Team / Reactive",
-            "publicAccess": "rw------",
             "sharing": {
                 "external": false,
                 "owner": "Q7lEw9NnaKS",
@@ -333,398 +219,12 @@
                 "users": {}
             },
             "skipTotal": false,
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
-        }
-    ],
-    "categoryOptionCombos": [
-        {
-            "created": "2022-07-18T10:22:58.662",
-            "dimensionItem": "z5ONfWrqp6b",
-            "displayFormName": "Preventive",
-            "displayName": "Preventive",
-            "displayShortName": "Preventive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "z5ONfWrqp6b",
-            "ignoreApproval": false,
-            "lastUpdated": "2022-07-18T10:52:03.313",
-            "lastUpdatedBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "legendSets": [],
-            "name": "Preventive",
-            "periodOffset": 0,
-            "sharing": {
-                "external": false,
-                "userGroups": {},
-                "users": {}
-            },
-            "shortName": "Preventive",
-            "translations": [],
-            "userAccesses": [],
-            "userGroupAccesses": []
-        },
-        {
-            "created": "2022-07-18T10:23:16.216",
-            "dimensionItem": "CjUzGG0Q01j",
-            "displayFormName": "Reactive",
-            "displayName": "Reactive",
-            "displayShortName": "Reactive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
-            "id": "CjUzGG0Q01j",
-            "ignoreApproval": false,
-            "lastUpdated": "2022-07-18T10:52:03.313",
-            "lastUpdatedBy": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "legendSets": [],
-            "name": "Reactive",
-            "periodOffset": 0,
-            "sharing": {
-                "external": false,
-                "userGroups": {},
-                "users": {}
-            },
-            "shortName": "Reactive",
-            "translations": [],
-            "userAccesses": [],
-            "userGroupAccesses": []
+            "translations": []
         }
     ],
     "categoryOptions": [
         {
             "attributeValues": [],
-            "categoryOptionCombos": [
-                {
-                    "id": "z5ONfWrqp6b"
-                },
-                {
-                    "id": "LqfxjR4ecz9"
-                },
-                {
-                    "id": "CLs8u2AW4r0"
-                },
-                {
-                    "id": "kzm5l6ZcDGT"
-                },
-                {
-                    "id": "NUi2EJ87vRU"
-                },
-                {
-                    "id": "XKXgoZRFKTQ"
-                },
-                {
-                    "id": "h1gIYT50vpI"
-                },
-                {
-                    "id": "BgWoyXE50ni"
-                },
-                {
-                    "id": "PPwi5nDp2zp"
-                },
-                {
-                    "id": "CD5jWoPebq8"
-                },
-                {
-                    "id": "ia4R1auQs0i"
-                },
-                {
-                    "id": "SCRsNtccKzS"
-                },
-                {
-                    "id": "c6mwqYpaPJt"
-                },
-                {
-                    "id": "MsbCpaXETUK"
-                },
-                {
-                    "id": "QUtJmVRa3Gj"
-                },
-                {
-                    "id": "YsFRsZIK5bS"
-                },
-                {
-                    "id": "mZh4AiB2Opo"
-                },
-                {
-                    "id": "zdRI34TWG65"
-                },
-                {
-                    "id": "dojFaCY7TBr"
-                },
-                {
-                    "id": "a8eQhWlrU2l"
-                },
-                {
-                    "id": "TwrCeGW47fZ"
-                },
-                {
-                    "id": "OJz7dUErOmv"
-                },
-                {
-                    "id": "kqQBBqpIbv2"
-                },
-                {
-                    "id": "CK8odP6J4Ue"
-                },
-                {
-                    "id": "YZuKcQFMERt"
-                },
-                {
-                    "id": "V0T1AtjbQYg"
-                },
-                {
-                    "id": "YcoxTv1DjXr"
-                },
-                {
-                    "id": "RF6Ua7BoXCC"
-                },
-                {
-                    "id": "IpeRHEuI2kM"
-                },
-                {
-                    "id": "X0557d1NQZu"
-                },
-                {
-                    "id": "KGlezBkVsEa"
-                },
-                {
-                    "id": "FOpGSN4FGZf"
-                },
-                {
-                    "id": "ubORMXHLIgc"
-                },
-                {
-                    "id": "F8VhiqZLL70"
-                },
-                {
-                    "id": "h1Jp25YCZfo"
-                },
-                {
-                    "id": "X5oVLABwvmO"
-                },
-                {
-                    "id": "DsiLmkGNOJD"
-                },
-                {
-                    "id": "k5hQn1He0bh"
-                },
-                {
-                    "id": "nF0aWtk9V4t"
-                },
-                {
-                    "id": "TwqxUWZl2gs"
-                },
-                {
-                    "id": "VS6plyrzfjz"
-                },
-                {
-                    "id": "zxWNllbVlwh"
-                },
-                {
-                    "id": "D0IjWRP1JjW"
-                },
-                {
-                    "id": "SgcKXgnac6H"
-                },
-                {
-                    "id": "PQdbfvD7l86"
-                },
-                {
-                    "id": "OrMrc07soqV"
-                },
-                {
-                    "id": "UQxGiZZbBid"
-                },
-                {
-                    "id": "vzu9spDJnOT"
-                },
-                {
-                    "id": "nXw4esiSZ6E"
-                },
-                {
-                    "id": "YxEjiBOzodp"
-                },
-                {
-                    "id": "gtKZ76nPqwU"
-                },
-                {
-                    "id": "NQL78EWZi0M"
-                },
-                {
-                    "id": "clPOHHqARC9"
-                },
-                {
-                    "id": "MJEc5GM9ebZ"
-                },
-                {
-                    "id": "x5Ll3MU3Pmv"
-                },
-                {
-                    "id": "BC9jIo6nXYK"
-                },
-                {
-                    "id": "FffDhySAnjk"
-                },
-                {
-                    "id": "ahxc8hezY2h"
-                },
-                {
-                    "id": "hNMccgHkdhW"
-                },
-                {
-                    "id": "Jk3e3qiO8sH"
-                },
-                {
-                    "id": "OUKBHfAPiuC"
-                },
-                {
-                    "id": "nCXZbLoaroS"
-                },
-                {
-                    "id": "WPx6ZgACaLq"
-                },
-                {
-                    "id": "RgHq78WUoHk"
-                },
-                {
-                    "id": "YHfbPgbEM9M"
-                },
-                {
-                    "id": "ogfoKkPDDCS"
-                },
-                {
-                    "id": "YZ6BYJ8TrZ9"
-                },
-                {
-                    "id": "lpTMeJOWCa7"
-                },
-                {
-                    "id": "VFT6qg8b2Yg"
-                },
-                {
-                    "id": "S3DXWIBIxrb"
-                },
-                {
-                    "id": "j59X0Wd7paT"
-                },
-                {
-                    "id": "l0Sts0o2bdB"
-                },
-                {
-                    "id": "TPXu4bLe2AW"
-                },
-                {
-                    "id": "L673BMO61rf"
-                },
-                {
-                    "id": "wj8403zfOOq"
-                },
-                {
-                    "id": "zklDL6kePpe"
-                },
-                {
-                    "id": "hUPhgTuHSI0"
-                },
-                {
-                    "id": "HPMpGczr0U4"
-                },
-                {
-                    "id": "zQ7GWrrL9Gr"
-                },
-                {
-                    "id": "DpqkjhtdwaC"
-                },
-                {
-                    "id": "TMWYhy2MmFl"
-                },
-                {
-                    "id": "Du31CSrLIXD"
-                },
-                {
-                    "id": "DXbgdnt3WtG"
-                },
-                {
-                    "id": "ouSoMu1qG3u"
-                },
-                {
-                    "id": "INxUusEpgw0"
-                },
-                {
-                    "id": "pk1O7fmoupI"
-                },
-                {
-                    "id": "MWAMwf12VlV"
-                },
-                {
-                    "id": "RAiPr6OYCyQ"
-                },
-                {
-                    "id": "l0OjU6cmfAp"
-                },
-                {
-                    "id": "agBsUMhmo8H"
-                },
-                {
-                    "id": "eKZR1hSgPG1"
-                },
-                {
-                    "id": "Oq31kQzdpN4"
-                },
-                {
-                    "id": "sUmJ9C2JzPL"
-                },
-                {
-                    "id": "w1AiCjvwqfn"
-                },
-                {
-                    "id": "GOzDa6Ndrra"
-                },
-                {
-                    "id": "y2U8KBjEYUz"
-                },
-                {
-                    "id": "qgHs1NmBz9X"
-                },
-                {
-                    "id": "QxEKmYKd9d7"
-                },
-                {
-                    "id": "grzjvra3sji"
-                },
-                {
-                    "id": "gRBYiMSXRbS"
-                },
-                {
-                    "id": "t4SRAOe4VFs"
-                },
-                {
-                    "id": "EuDT0ywuT1Q"
-                },
-                {
-                    "id": "oMcwQxe9egp"
-                },
-                {
-                    "id": "Q9b8KeEGh6r"
-                }
-            ],
             "code": "RVC_PREVENTIVE",
             "created": "2022-07-15T08:39:58.813",
             "createdBy": {
@@ -733,27 +233,16 @@
                 "name": "admin admin",
                 "username": "admin"
             },
-            "dimensionItem": "p5Sd5DIKYHy",
-            "dimensionItemType": "CATEGORY_OPTION",
-            "displayFormName": "Preventive",
-            "displayName": "Preventive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
             "id": "p5Sd5DIKYHy",
-            "isDefault": false,
-            "lastUpdated": "2022-07-18T10:52:03.287",
+            "lastUpdated": "2022-07-20T13:46:59.658",
             "lastUpdatedBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
                 "name": "admin admin",
                 "username": "admin"
             },
-            "legendSets": [],
             "name": "Preventive",
             "organisationUnits": [],
-            "periodOffset": 0,
-            "publicAccess": "rwrw----",
             "sharing": {
                 "external": false,
                 "owner": "Q7lEw9NnaKS",
@@ -761,332 +250,10 @@
                 "userGroups": {},
                 "users": {}
             },
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
+            "translations": []
         },
         {
             "attributeValues": [],
-            "categoryOptionCombos": [
-                {
-                    "id": "Z71VUCLq6px"
-                },
-                {
-                    "id": "p1A4X8Wrjpo"
-                },
-                {
-                    "id": "yZH1z8prDVZ"
-                },
-                {
-                    "id": "hzRgsMBe9mj"
-                },
-                {
-                    "id": "QljiNRsyvuG"
-                },
-                {
-                    "id": "fceyA8t6oT8"
-                },
-                {
-                    "id": "s8YmqOllqJZ"
-                },
-                {
-                    "id": "UAJ1JnLjt1a"
-                },
-                {
-                    "id": "XYATw8rpqnf"
-                },
-                {
-                    "id": "Hx0ridkJ1MN"
-                },
-                {
-                    "id": "P1kcNNDqU2Q"
-                },
-                {
-                    "id": "m1DpaMSy8f6"
-                },
-                {
-                    "id": "iKzcLBksTBN"
-                },
-                {
-                    "id": "z81H86NSCwq"
-                },
-                {
-                    "id": "qTpBStzsQpn"
-                },
-                {
-                    "id": "xvlI8CIjKbN"
-                },
-                {
-                    "id": "MD4X2yqUH1q"
-                },
-                {
-                    "id": "EPVqzCZTg7a"
-                },
-                {
-                    "id": "G61tcVneIXJ"
-                },
-                {
-                    "id": "bWRuiIXSbAO"
-                },
-                {
-                    "id": "tTPlK93HY0L"
-                },
-                {
-                    "id": "k5rSduXudwk"
-                },
-                {
-                    "id": "ZPGNXxrI91x"
-                },
-                {
-                    "id": "GKfwcQscEZv"
-                },
-                {
-                    "id": "cSJYD8cA2HK"
-                },
-                {
-                    "id": "PK6zZ5CQnk5"
-                },
-                {
-                    "id": "yhHv0ag4J7h"
-                },
-                {
-                    "id": "Mcrlpq1aTTk"
-                },
-                {
-                    "id": "ADRyCcGqM7T"
-                },
-                {
-                    "id": "XVCSKEknbGp"
-                },
-                {
-                    "id": "XCo1lRdcU0Q"
-                },
-                {
-                    "id": "svbhLIfmbpT"
-                },
-                {
-                    "id": "AQxtA4ioqbD"
-                },
-                {
-                    "id": "JuTI7osAcnZ"
-                },
-                {
-                    "id": "RT9JGVuoc71"
-                },
-                {
-                    "id": "OX8TlKPMLI0"
-                },
-                {
-                    "id": "HH8vlzq1uKf"
-                },
-                {
-                    "id": "YZBi1G2yJ25"
-                },
-                {
-                    "id": "WOcfCwXVXgb"
-                },
-                {
-                    "id": "Ph0QN5acqsR"
-                },
-                {
-                    "id": "Eyzc7alLSHA"
-                },
-                {
-                    "id": "fePcr7nSAd6"
-                },
-                {
-                    "id": "twO1ZZt25wV"
-                },
-                {
-                    "id": "cSJ1gRiWrde"
-                },
-                {
-                    "id": "aok82tv9ciz"
-                },
-                {
-                    "id": "d9l5UvrOKqw"
-                },
-                {
-                    "id": "uvVCdPmcXfq"
-                },
-                {
-                    "id": "lPAOoZKRUNt"
-                },
-                {
-                    "id": "Gi65PoT0gGN"
-                },
-                {
-                    "id": "H0yRbZpCOaK"
-                },
-                {
-                    "id": "yuevFAX8JPy"
-                },
-                {
-                    "id": "YzLVqOHbDfr"
-                },
-                {
-                    "id": "YBtgVLvQw3q"
-                },
-                {
-                    "id": "KAe6MTtj8SK"
-                },
-                {
-                    "id": "x8Td55DQ6fc"
-                },
-                {
-                    "id": "PoAC4cDCTAJ"
-                },
-                {
-                    "id": "SvqczA24EBF"
-                },
-                {
-                    "id": "rOjueLPNlxk"
-                },
-                {
-                    "id": "DDxQPI7rkqc"
-                },
-                {
-                    "id": "i6LX8Wv6UBG"
-                },
-                {
-                    "id": "zI6xP1nLiGG"
-                },
-                {
-                    "id": "lgJ4m5dWs2R"
-                },
-                {
-                    "id": "ZRvpY7N2t1G"
-                },
-                {
-                    "id": "qf98ppDGxwB"
-                },
-                {
-                    "id": "UiPbSpsOAfC"
-                },
-                {
-                    "id": "rFfEX144NmR"
-                },
-                {
-                    "id": "phu8leew1vW"
-                },
-                {
-                    "id": "iRG6J5hh0lA"
-                },
-                {
-                    "id": "wzgwXCBh9LH"
-                },
-                {
-                    "id": "NJvvbYUXfuB"
-                },
-                {
-                    "id": "ESYXKpgsH3b"
-                },
-                {
-                    "id": "qqMaIsUIEW4"
-                },
-                {
-                    "id": "j6bqbtRz6Af"
-                },
-                {
-                    "id": "iDo77qMSVci"
-                },
-                {
-                    "id": "VgAsxyq7krg"
-                },
-                {
-                    "id": "bnv4qGJGiP6"
-                },
-                {
-                    "id": "xznRg2ms62A"
-                },
-                {
-                    "id": "nqKhN1DKRpN"
-                },
-                {
-                    "id": "JkZYMYcsNsT"
-                },
-                {
-                    "id": "TPlvf9AxxtQ"
-                },
-                {
-                    "id": "bbGqalcImkm"
-                },
-                {
-                    "id": "I3VLgKRy4Iz"
-                },
-                {
-                    "id": "o6QeVqZ9LZT"
-                },
-                {
-                    "id": "ZUf1SDndcYD"
-                },
-                {
-                    "id": "h5CDE28IKfy"
-                },
-                {
-                    "id": "m0qcAyddGWb"
-                },
-                {
-                    "id": "Z3GjwqGO9K8"
-                },
-                {
-                    "id": "zY3k8woQqRJ"
-                },
-                {
-                    "id": "V5ITTM9jIK3"
-                },
-                {
-                    "id": "KQ4DDJS94WM"
-                },
-                {
-                    "id": "U8OjammT44m"
-                },
-                {
-                    "id": "cRltFoURpHo"
-                },
-                {
-                    "id": "WcIB9o8QKz8"
-                },
-                {
-                    "id": "u600juThIE1"
-                },
-                {
-                    "id": "iGFIv5MHhrd"
-                },
-                {
-                    "id": "xycwJg6wsln"
-                },
-                {
-                    "id": "aTdpePCIMXt"
-                },
-                {
-                    "id": "wRBF7LCCUvU"
-                },
-                {
-                    "id": "CjUzGG0Q01j"
-                },
-                {
-                    "id": "f93OUrettAp"
-                },
-                {
-                    "id": "vLPO8a7XeBn"
-                },
-                {
-                    "id": "Z5bY612ORYd"
-                },
-                {
-                    "id": "FnxbyefbiCY"
-                },
-                {
-                    "id": "qjF3IYvX9Fm"
-                }
-            ],
             "code": "RVC_REACTIVE",
             "created": "2022-07-15T08:39:53.295",
             "createdBy": {
@@ -1095,27 +262,16 @@
                 "name": "admin admin",
                 "username": "admin"
             },
-            "dimensionItem": "IhLAod6GvkU",
-            "dimensionItemType": "CATEGORY_OPTION",
-            "displayFormName": "Reactive",
-            "displayName": "Reactive",
-            "externalAccess": false,
-            "favorite": false,
-            "favorites": [],
             "id": "IhLAod6GvkU",
-            "isDefault": false,
-            "lastUpdated": "2022-07-18T10:52:03.287",
+            "lastUpdated": "2022-07-20T13:46:59.658",
             "lastUpdatedBy": {
                 "displayName": "admin admin",
                 "id": "Q7lEw9NnaKS",
                 "name": "admin admin",
                 "username": "admin"
             },
-            "legendSets": [],
             "name": "Reactive",
             "organisationUnits": [],
-            "periodOffset": 0,
-            "publicAccess": "rwrw----",
             "sharing": {
                 "external": false,
                 "owner": "Q7lEw9NnaKS",
@@ -1123,15 +279,7 @@
                 "userGroups": {},
                 "users": {}
             },
-            "translations": [],
-            "user": {
-                "displayName": "admin admin",
-                "id": "Q7lEw9NnaKS",
-                "name": "admin admin",
-                "username": "admin"
-            },
-            "userAccesses": [],
-            "userGroupAccesses": []
+            "translations": []
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vaccination-app",
     "description": "DHIS2 MSF Reactive Vaccination App",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "cy:verify": "cypress verify",
         "cy:e2e:open": "CYPRESS_E2E=true cypress open",
         "cy:e2e:run": "CYPRESS_E2E=true cypress run",
-        "tasks": "npx ts-node -P tsconfig-cli.json src/scripts/tasks.ts"
+        "tasks": "node --max-old-space-size=4096 -- node_modules/ts-node/dist/bin -P tsconfig-cli.json src/scripts/tasks.ts"
     },
     "husky": {
         "hooks": {
@@ -84,6 +84,7 @@
         "@types/react-dom": "^16.0.11",
         "babel-core": "7.0.0-bridge.0",
         "cmd-ts": "^0.11.0",
+        "csv-writer": "^1.6.0",
         "cypress": "^3.1.5",
         "cypress-xpath": "^1.3.0",
         "eslint": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
         "manifest": "d2-manifest package.json build/manifest.webapp",
         "cy:verify": "cypress verify",
         "cy:e2e:open": "CYPRESS_E2E=true cypress open",
-        "cy:e2e:run": "CYPRESS_E2E=true cypress run"
+        "cy:e2e:run": "CYPRESS_E2E=true cypress run",
+        "tasks": "npx ts-node -P tsconfig-cli.json src/scripts/tasks.ts"
     },
     "husky": {
         "hooks": {
@@ -76,11 +77,13 @@
     },
     "devDependencies": {
         "@babel/core": "^7.0.0-0",
+        "@eyeseetea/d2-api": "^1.13.1",
         "@types/jest": "^23.3.13",
         "@types/node": "^10.12.19",
         "@types/react": "^16.7.22",
         "@types/react-dom": "^16.0.11",
         "babel-core": "7.0.0-bridge.0",
+        "cmd-ts": "^0.11.0",
         "cypress": "^3.1.5",
         "cypress-xpath": "^1.3.0",
         "eslint": "^5.12.1",
@@ -97,6 +100,7 @@
         "raw-loader": "^3.1.0",
         "sinon": "^7.1.1",
         "ts-jest": "^23.10.5",
+        "ts-node": "9",
         "typescript": "4.6.2",
         "wait-on": "^3.2.0"
     },

--- a/src/components/forms/SimpleSelect.tsx
+++ b/src/components/forms/SimpleSelect.tsx
@@ -1,26 +1,55 @@
-import React, { SFC } from "react";
-import { Select, MenuItem } from "@material-ui/core";
+import React from "react";
+import { Select, MenuItem, FormControl, InputLabel } from "@material-ui/core";
 
 interface SimpleSelectProps {
     value: string;
     options: Array<{ text: string; value: string }>;
     onChange: (value: string) => void;
+    style?: React.CSSProperties;
+    floatingLabelText?: string;
 }
 
-const SimpleSelect: SFC<SimpleSelectProps> = ({ value, options, onChange }) => {
+const SimpleSelect: React.FC<SimpleSelectProps> = props => {
+    const { value, options, onChange, style, floatingLabelText } = props;
+
     const _onChange = (ev: React.ChangeEvent<HTMLSelectElement>) => {
         onChange(ev.target.value);
     };
 
     return (
-        <Select value={value} onChange={_onChange}>
-            {options.map(option => (
-                <MenuItem key={option.value} value={option.value}>
-                    {option.text}
-                </MenuItem>
-            ))}
-        </Select>
+        <div style={style}>
+            <Wrapper label={floatingLabelText}>
+                <Select value={value} onChange={_onChange}>
+                    {options.map(option => (
+                        <MenuItem key={option.value} value={option.value}>
+                            {option.text}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </Wrapper>
+        </div>
     );
+};
+
+const Wrapper: React.FC<{ label?: string }> = props => {
+    const { children, label } = props;
+
+    if (label) {
+        return (
+            <FormControl style={styles.formControl}>
+                <InputLabel>{label}</InputLabel>
+                {props.children}
+            </FormControl>
+        );
+    } else {
+        return <>{children}</>;
+    }
+};
+
+const styles = {
+    formControl: {
+        minWidth: 220,
+    },
 };
 
 export default SimpleSelect;

--- a/src/components/steps/general-info/GeneralInfoStep.jsx
+++ b/src/components/steps/general-info/GeneralInfoStep.jsx
@@ -12,6 +12,8 @@ import { Validators } from "@dhis2/d2-ui-forms";
 
 import { DatePicker } from "d2-ui-components";
 import { translateError } from "../../../utils/validations";
+import SimpleSelect from "../../forms/SimpleSelect";
+import { getTranslations } from "../../../models/campaign";
 
 class GeneralInfoStep extends React.Component {
     state = {
@@ -41,6 +43,9 @@ class GeneralInfoStep extends React.Component {
             case "name":
                 newCampaign = campaign.setName(newValue);
                 break;
+            case "type":
+                newCampaign = campaign.setType(newValue);
+                break;
             case "description":
                 newCampaign = campaign.setDescription(newValue);
                 break;
@@ -59,6 +64,8 @@ class GeneralInfoStep extends React.Component {
 
     render() {
         const { campaign } = this.props;
+        const translations = getTranslations();
+
         const fields = [
             {
                 name: "name",
@@ -77,6 +84,24 @@ class GeneralInfoStep extends React.Component {
                     },
                 ],
                 asyncValidators: [this.validateCampaignName],
+            },
+            {
+                name: "type",
+                value: campaign.type,
+                component: props => {
+                    return (
+                        <SimpleSelect
+                            {...props}
+                            onChange={value => props.onChange({ target: { value } })}
+                        />
+                    );
+                },
+                props: {
+                    "data-field": "type",
+                    floatingLabelText: i18n.t("Type"),
+                    options: _.map(translations.type, (text, value) => ({ value, text })),
+                    style: { marginTop: 20, width: "33%" },
+                },
             },
             {
                 name: "description",

--- a/src/components/steps/save/SaveStep.jsx
+++ b/src/components/steps/save/SaveStep.jsx
@@ -10,6 +10,7 @@ import { withSnackbar } from "d2-ui-components";
 
 import { getFullOrgUnitName } from "../../../models/organisation-units";
 import ExitWizardButton from "../../wizard/ExitWizardButton";
+import { getTranslations } from "../../../models/campaign";
 
 const styles = _theme => ({
     wrapper: {
@@ -160,6 +161,7 @@ class SaveStep extends React.Component {
 
         const LiEntry = this.renderLiEntry;
         const disaggregation = campaign.getEnabledAntigensDisaggregation();
+        const translations = getTranslations();
 
         return (
             <React.Fragment>
@@ -171,6 +173,10 @@ class SaveStep extends React.Component {
                 <div className={classes.wrapper}>
                     <ul>
                         <LiEntry label={i18n.t("Name")} value={campaign.name} />
+                        <LiEntry
+                            label={i18n.t("Type")}
+                            value={translations.type[campaign.type] || "-"}
+                        />
 
                         <LiEntry
                             label={i18n.t("Period dates")}

--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -28,7 +28,7 @@ import {
     getByIndex,
     MetadataConfig,
     baseConfig,
-    categoryComboTypeMapping,
+    categoryComboTeamTypeMapping,
 } from "./config";
 import { config } from "process";
 
@@ -143,7 +143,7 @@ export default class CampaignDb {
         const campaignDisaggregation = this.getCampaignDisaggregation(disaggregationData);
 
         const categoryComboCode =
-            categoryComboTypeMapping[campaign.type] || config.categoryComboCodeForReactive;
+            categoryComboTeamTypeMapping[campaign.type] || config.categoryComboCodeForTeamReactive;
         const categoryComboId = getByIndex(config.categoryCombos, "code", categoryComboCode).id;
 
         const dataSet: DataSet = {
@@ -398,7 +398,7 @@ export default class CampaignDb {
     ): Promise<DashboardMetadata> {
         const { campaign } = this;
         const { db, config: metadataConfig } = campaign;
-        const dashboardGenerator = Dashboard.build(db);
+        const dashboardGenerator = Dashboard.build(db, metadataConfig);
 
         if (!campaign.startDate || !campaign.endDate) {
             throw new Error("Campaign Dates not set");
@@ -410,6 +410,7 @@ export default class CampaignDb {
         const sharing = await campaign.getDashboardSharing();
 
         return dashboardGenerator.create({
+            campaign,
             dashboardId: campaign.dashboardId,
             datasetName: campaign.name,
             organisationUnits: campaign.organisationUnits,

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -7,7 +7,7 @@ import {
     buildDashboardItems,
 } from "./dashboard-items";
 import { Ref, OrganisationUnitPathOnly, OrganisationUnitWithName, Sharing } from "./db.types";
-import { Antigen } from "./campaign";
+import Campaign, { Antigen } from "./campaign";
 import { Moment } from "moment";
 import { getDaysRange } from "../utils/date";
 import { AntigenDisaggregationEnabled } from "./AntigensDisaggregation";
@@ -41,10 +41,10 @@ export type DashboardMetadata = {
 };
 
 export class Dashboard {
-    constructor(private db: DbD2) {}
+    constructor(private db: DbD2, private metadataConfig: MetadataConfig) {}
 
-    static build(db: DbD2) {
-        return new Dashboard(db);
+    static build(db: DbD2, metadataConfig: MetadataConfig) {
+        return new Dashboard(db, metadataConfig);
     }
 
     private async getMetadataForDashboardItems(
@@ -139,6 +139,7 @@ export class Dashboard {
     }
 
     public async create({
+        campaign,
         dashboardId,
         datasetName,
         organisationUnits,
@@ -152,6 +153,7 @@ export class Dashboard {
         sharing,
         allCategoryIds,
     }: {
+        campaign: Campaign;
         dashboardId?: string;
         datasetName: string;
         organisationUnits: OrganisationUnitPathOnly[];
@@ -175,6 +177,7 @@ export class Dashboard {
         );
 
         const dashboardItems = this.createDashboardItems(
+            campaign,
             datasetName,
             startDate,
             endDate,
@@ -202,6 +205,7 @@ export class Dashboard {
     }
 
     createDashboardItems(
+        campaign: Campaign,
         datasetName: String,
         startDate: Moment,
         endDate: Moment,
@@ -234,6 +238,8 @@ export class Dashboard {
             .value();
 
         const dashboardItems = buildDashboardItems(
+            campaign,
+            this.metadataConfig,
             antigensMeta,
             datasetName,
             organisationUnitsMetadata,

--- a/src/models/TargetPopulation.ts
+++ b/src/models/TargetPopulation.ts
@@ -3,7 +3,7 @@ const fp = require("lodash/fp");
 import moment from "moment";
 
 import DbD2 from "./db-d2";
-import { categoryOptionMapping, MetadataConfig } from "./config";
+import { MetadataConfig } from "./config";
 import { Maybe, DataValue } from "./db.types";
 import { OrganisationUnit, OrganisationUnitPathOnly, OrganisationUnitLevel } from "./db.types";
 import { AntigenDisaggregationEnabled } from "./AntigensDisaggregation";

--- a/src/models/__tests__/config-mock.ts
+++ b/src/models/__tests__/config-mock.ts
@@ -2,6 +2,12 @@ import { MetadataConfig, baseConfig } from "../config";
 
 const metadataConfig: MetadataConfig = {
     ...baseConfig,
+    disaggregations: {
+        campaignType: {
+            preventive: "id1",
+            reactive: "id2",
+        },
+    },
     userRoles: [],
     organisationUnitLevels: [],
     categoryCombos: [],

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -17,7 +17,10 @@ const expectedFields = [
     "organisationUnits[id,path]",
 ];
 
-const createdByAppFilters = ["attributeValues.attribute.id:eq:1", "categoryCombo.code:eq:RVC_TEAM"];
+const createdByAppFilters = [
+    "attributeValues.attribute.id:eq:1",
+    "categoryCombo.code:in:[RVC_TEAM,RVC_TEAM_REACTIVE,RVC_TEAM_PREVENTIVE]",
+];
 const emptyCollection = { pager: { page: 1, total: 0 }, toArray: () => [] };
 const listMock = jest.fn(() => Promise.resolve(emptyCollection));
 

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -29,9 +29,14 @@ export const baseConfig = {
     dataElementGroupCodeForAntigens: "RVC_ANTIGEN",
     dataElementGroupCodeForPopulation: "RVC_POPULATION",
     categoryComboCodeForTeams: "RVC_TEAM",
-    categoryComboCodeForReactive: "RVC_TEAM_REACTIVE",
-    categoryComboCodeForPreventive: "RVC_TEAM_PREVENTIVE",
+    categoryComboCodeForTeamReactive: "RVC_TEAM_REACTIVE",
+    categoryComboCodeForTeamPreventive: "RVC_TEAM_PREVENTIVE",
+    categoryComboCodeForReactive: "RVC_REACTIVE",
+    categoryComboCodeForPreventive: "RVC_PREVENTIVE",
+    categoryCodeForCampaignType: "RVC_CAMPAIGN_TYPE",
     categoryCodeForTeams: "RVC_TEAM",
+    categoryOptionCodeForReactive: "RVC_REACTIVE",
+    categoryOptionCodeForPreventive: "RVC_PREVENTIVE",
     legendSetsCode: "RVC_LEGEND_ZERO",
     attributeCodeForApp: "RVC_CREATED_BY_VACCINATION_APP",
     attributeNameForHideInTallySheet: "hideInTallySheet",
@@ -410,11 +415,21 @@ export async function getMetadataConfig(db: DbD2): Promise<MetadataConfig> {
 }
 
 export const typeCategoryComboMapping: Record<string, CampaignType> = {
-    [baseConfig.categoryComboCodeForReactive]: "reactive",
-    [baseConfig.categoryComboCodeForPreventive]: "preventive",
+    [baseConfig.categoryComboCodeForTeamReactive]: "reactive",
+    [baseConfig.categoryComboCodeForTeamPreventive]: "preventive",
+};
+
+export const categoryComboTeamTypeMapping: Record<CampaignType, string> = {
+    reactive: baseConfig.categoryComboCodeForTeamReactive,
+    preventive: baseConfig.categoryComboCodeForTeamPreventive,
 };
 
 export const categoryComboTypeMapping: Record<CampaignType, string> = {
     reactive: baseConfig.categoryComboCodeForReactive,
     preventive: baseConfig.categoryComboCodeForPreventive,
+};
+
+export const categoryOptionMapping: Record<CampaignType, string> = {
+    reactive: baseConfig.categoryOptionCodeForReactive,
+    preventive: baseConfig.categoryOptionCodeForPreventive,
 };

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -16,6 +16,7 @@ import {
     Indicator,
 } from "./db.types";
 import { sortAgeGroups } from "../utils/age-groups";
+import { CampaignType } from "./campaign";
 
 export const baseConfig = {
     expirationDays: 8,
@@ -28,6 +29,8 @@ export const baseConfig = {
     dataElementGroupCodeForAntigens: "RVC_ANTIGEN",
     dataElementGroupCodeForPopulation: "RVC_POPULATION",
     categoryComboCodeForTeams: "RVC_TEAM",
+    categoryComboCodeForReactive: "RVC_TEAM_REACTIVE",
+    categoryComboCodeForPreventive: "RVC_TEAM_PREVENTIVE",
     categoryCodeForTeams: "RVC_TEAM",
     legendSetsCode: "RVC_LEGEND_ZERO",
     attributeCodeForApp: "RVC_CREATED_BY_VACCINATION_APP",
@@ -405,3 +408,13 @@ export async function getMetadataConfig(db: DbD2): Promise<MetadataConfig> {
 
     return metadataConfig;
 }
+
+export const typeCategoryComboMapping: Record<string, CampaignType> = {
+    [baseConfig.categoryComboCodeForReactive]: "reactive",
+    [baseConfig.categoryComboCodeForPreventive]: "preventive",
+};
+
+export const categoryComboTypeMapping: Record<CampaignType, string> = {
+    reactive: baseConfig.categoryComboCodeForReactive,
+    preventive: baseConfig.categoryComboCodeForPreventive,
+};

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -40,8 +40,8 @@ export async function list(config, d2, filters, pagination) {
 
     const categoryComboCodes = [
         config.categoryCodeForTeams,
-        config.categoryComboCodeForReactive,
-        config.categoryComboCodeForPreventive,
+        config.categoryComboCodeForTeamReactive,
+        config.categoryComboCodeForTeamPreventive,
     ];
 
     const filter = _.compact([

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -38,11 +38,17 @@ export async function list(config, d2, filters, pagination) {
     const [field, direction] = sorting || [];
     const order = field && direction ? `${field}:i${direction}` : undefined;
 
+    const categoryComboCodes = [
+        config.categoryCodeForTeams,
+        config.categoryComboCodeForReactive,
+        config.categoryComboCodeForPreventive,
+    ];
+
     const filter = _.compact([
         search ? `displayName:ilike:${search}` : null,
         // Preliminar filters (presence of attribute createdByApp and categoryCombo=TEAMS)
         `attributeValues.attribute.id:eq:${config.attributes.app.id}`,
-        `categoryCombo.code:eq:${config.categoryCodeForTeams}`,
+        `categoryCombo.code:in:[${categoryComboCodes.join(",")}]`,
     ]);
     const fields = (forcedFields || defaultListFields).concat(requiredFields).join(",");
     const listOptions = { fields, filter, pageSize: 1000, order };

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -96,6 +96,7 @@ export interface GetDataValuesParams {
     period?: string[];
     includeDeleted?: boolean;
     lastUpdated?: string;
+    attributeOptionCombo?: string;
     limit?: number;
     startDate?: Date;
     endDate?: Date;

--- a/src/scripts/tasks.ts
+++ b/src/scripts/tasks.ts
@@ -5,8 +5,9 @@ import path from "path";
 import { command, run, string, option, subcommands, Type, flag } from "cmd-ts";
 import { D2Api, DataValueSetsDataValue, Id, MetadataPick } from "@eyeseetea/d2-api/2.36";
 import { baseConfig } from "../models/config";
-import { NamedRef } from "../models/db.types";
 import { promiseMap } from "../utils/promises";
+
+type NamedRef = { id: string; name: string };
 
 function main() {
     const updateDataValuesDisaggregation = command({
@@ -140,10 +141,11 @@ class UpdateCampaignsDisaggregation {
             const campaignType = isPreventiveOrgUnit ? "preventive" : "reactive";
             const mapping = aocMapping[campaignType];
             const aocIdMapped = mapping[dv.attributeOptionCombo];
+            const orgUnit = orgUnitsById[dv.orgUnit];
 
             const base: Omit<ReportRow, "toAoc"> = {
                 orgUnit: formatObj(orgUnitsById[dv.orgUnit]),
-                orgUnitLevel: orgUnitsById[dv.orgUnit]?.level.toString(),
+                orgUnitLevel: orgUnit ? orgUnit.level.toString() : "",
                 dataElement: formatObj(dataElementsById[dv.dataElement]),
                 period: dv.period,
                 value: dv.value,
@@ -330,7 +332,11 @@ class UpdateCampaignsDisaggregation {
 
 const metadataQuery = {
     dataSets: {
-        fields: { id: true, name: true, organisationUnits: { id: true, level: true, parent: {id: true} } },
+        fields: {
+            id: true,
+            name: true,
+            organisationUnits: { id: true, level: true, parent: { id: true } },
+        },
     },
     dataElements: {
         fields: { id: true, name: true },

--- a/src/scripts/tasks.ts
+++ b/src/scripts/tasks.ts
@@ -1,9 +1,12 @@
 import _ from "lodash";
 import fs from "fs";
+import * as CsvWriter from "csv-writer";
 import path from "path";
 import { command, run, string, option, subcommands, Type, flag } from "cmd-ts";
 import { D2Api, DataValueSetsDataValue, Id, MetadataPick } from "@eyeseetea/d2-api/2.36";
 import { baseConfig } from "../models/config";
+import { NamedRef } from "../models/db.types";
+import { promiseMap } from "../utils/promises";
 
 function main() {
     const updateDataValuesDisaggregation = command({
@@ -65,17 +68,25 @@ interface Options {
 }
 
 class UpdateCampaignsDisaggregation {
+    preventiveDataSets = [
+        "CAR - PCV/Penta November",
+        "Dasenech Emergency project",
+        "RVC NADIAGOU : PCV13/PENTA/VAR/VAA/MEN A/ROTA",
+        "RVC multiantigenes de deplacé de Yamba à Fada le Fevrier 2022",
+        "RVC_Tambura_Measles_March-2022",
+    ];
     constructor(private api: D2Api, private options: Options) {}
 
     async execute() {
         const { api, options } = this;
         const metadata = await api.metadata.get(metadataQuery).getData();
-        const aocMapping = this.getAoCMapping(metadata);
+        const aocMapping = this.getAttributeOptionComboMapping(metadata);
         const dataValues = await this.getDataValues(metadata);
-        const dataValuesWithAocMapped = this.getMappedDataValues(dataValues, aocMapping);
-        debug(`Mapped: ${dataValues.length} -> ${dataValuesWithAocMapped.length}`);
-
-        await this.persistDataValues(dataValuesWithAocMapped, options, api);
+        const data = this.getMappedDataValues(metadata, dataValues, aocMapping);
+        const dataValuesMapped = _.compact(data.map(o => o.dataValue));
+        await this.persistDataValues(dataValuesMapped, options, api);
+        await this.saveReport(data.map(o => o.row));
+        debug(`Data values: original=${dataValues.length}, mapped=${dataValuesMapped.length}`);
     }
 
     private async persistDataValues(
@@ -83,7 +94,7 @@ class UpdateCampaignsDisaggregation {
         options: Options,
         api: D2Api
     ) {
-        const groups = _.chunk(dataValuesWithAocMapped, 100000);
+        const groups = _.chunk(dataValuesWithAocMapped, 100_000);
 
         for (const [index, dataValuesGroup] of groups.entries()) {
             const payload = { dataValues: dataValuesGroup };
@@ -91,7 +102,7 @@ class UpdateCampaignsDisaggregation {
             const paddedIndex = padDigits(index, 4);
             const outputPath = options.outputPath.replace(/\.json$/, `-${paddedIndex}.json`);
             fs.writeFileSync(outputPath, json);
-            debug(`Written [${index + 1}/${groups.length}]: ${outputPath}`);
+            debug(`Payload [${index + 1}/${groups.length}]: ${outputPath}`);
 
             if (options.post) {
                 debug(`Post data values: ${dataValuesGroup.length}`);
@@ -104,22 +115,51 @@ class UpdateCampaignsDisaggregation {
     }
 
     private getMappedDataValues(
+        metadata: Metadata,
         dataValues: DataValueSetsDataValue[],
-        aocMapping: Record<string, string>
+        aocMapping: CampaignCocMapping
     ) {
+        const dataSetsByName = _.keyBy(metadata.dataSets, ds => ds.name.trim());
+        const names = this.preventiveDataSets.join(", ");
+        debug(`All data sets will be considered reactive, except for: ${names}`);
+
+        const preventiveOrgUnitIds = new Set(
+            _(this.preventiveDataSets)
+                .map(dataSetName => _(dataSetsByName).getOrFail(dataSetName))
+                .flatMap(dataSet => dataSet.organisationUnits)
+                .value()
+                .map(ou => ou.id)
+        );
+
+        const orgUnitsById = byId(metadata.organisationUnits);
+        const dataElementsById = byId(metadata.dataElements);
+        const cocsById = byId(_.flatMap(metadata.categoryCombos, cc => cc.categoryOptionCombos));
+
         return _(dataValues)
             .map(
-                (dataValue): DataValueSetsDataValue | undefined => {
-                    const attributeOptionComboMapped = aocMapping[dataValue.attributeOptionCombo];
+                (dv): { row: ReportRow; dataValue: DataValueSetsDataValue | undefined } => {
+                    const isPreventiveOrgUnit = preventiveOrgUnitIds.has(dv.orgUnit);
+                    const campaignType = isPreventiveOrgUnit ? "preventive" : "reactive";
+                    const mapping = aocMapping[campaignType];
+                    const aocMapped = mapping[dv.attributeOptionCombo];
 
-                    if (!attributeOptionComboMapped) {
-                        const msg = `Cannot map aoc: ${dataValue.attributeOptionCombo}`;
-                        debug(msg);
+                    const base: Omit<ReportRow, "toAoc"> = {
+                        orgUnit: formatObj(orgUnitsById[dv.orgUnit]),
+                        dataElement: formatObj(dataElementsById[dv.dataElement]),
+                        period: dv.period,
+                        value: dv.value,
+                        type: campaignType,
+                        fromAoc: formatObj(cocsById[dv.attributeOptionCombo]),
+                    };
+
+                    if (!aocMapped) {
+                        const row: ReportRow = { ...base, toAoc: "NOT FOUND" };
+                        debug(`Cannot map: ${row.orgUnit} - ${row.fromAoc}`);
+                        return { row, dataValue: undefined };
                     } else {
-                        return {
-                            ...dataValue,
-                            attributeOptionCombo: attributeOptionComboMapped,
-                        };
+                        const row: ReportRow = { ...base, toAoc: formatObj(cocsById[aocMapped]) };
+                        const dataValueUpdated = { ...dv, attributeOptionCombo: aocMapped };
+                        return { row, dataValue: dataValueUpdated };
                     }
                 }
             )
@@ -127,12 +167,36 @@ class UpdateCampaignsDisaggregation {
             .value();
     }
 
+    private async saveReport(rows: ReportRow[]) {
+        const header: Array<{ id: Attr; title: string }> = [
+            { id: "orgUnit", title: "Org Unit" },
+            { id: "dataElement", title: "Data element" },
+            { id: "period", title: "Period" },
+            { id: "value", title: "Value" },
+            { id: "type", title: "Type" },
+            { id: "fromAoc", title: "From" },
+            { id: "toAoc", title: "To" },
+        ];
+
+        const chunks = _(rows)
+            .chunk(1e6)
+            .map((chunk, index) => [chunk, index + 1] as const)
+            .value();
+
+        await promiseMap(chunks, ([rowChunk, index]) => {
+            const csvPath = `update-datavalues-disaggregation-${index}.csv`;
+            const obj = CsvWriter.createObjectCsvWriter({ path: csvPath, header });
+            debug(`Report [${index}/${chunks.length}]: ${csvPath}`);
+            return obj.writeRecords(rowChunk);
+        });
+    }
+
     private async getDataValues(metadata: Metadata): Promise<DataValueSetsDataValue[]> {
         const dataElementGroupAll = _(metadata.dataElementGroups)
             .keyBy(deg => deg.code)
             .getOrFail(baseConfig.dataElementGroupCodeForAntigens);
 
-        debug("Get data values");
+        debug(`Get data values from the API`);
         const { dataValues } = await this.api.dataValues
             .getSet({
                 orgUnit: this.options.orgUnitsIds,
@@ -147,11 +211,56 @@ class UpdateCampaignsDisaggregation {
         return dataValues;
     }
 
-    getAoCMapping(metadata: Metadata): Record<CocId, CocId> {
+    getAttributeOptionComboMapping(metadata: Metadata): CampaignCocMapping {
         const defaultCategoryCombo = _(metadata.categoryCombos)
             .keyBy(cc => cc.name)
             .getOrFail("default");
 
+        const categoryCombosByCode = _.keyBy(metadata.categoryCombos, cc => cc.code);
+        const campaignTypeCombo = _(categoryCombosByCode).getOrFail(
+            baseConfig.categoryCodeForCampaignType
+        );
+
+        const { categoryOptionCodeForReactive, categoryOptionCodeForPreventive } = baseConfig;
+
+        const cocForReactive = _(campaignTypeCombo.categoryOptionCombos)
+            .filter(coc =>
+                _(coc.categoryOptions).some(co => co.code === categoryOptionCodeForReactive)
+            )
+            .getOrFail(0);
+
+        const cocForPreventive = _(campaignTypeCombo.categoryOptionCombos)
+            .filter(coc =>
+                _(coc.categoryOptions).some(co => co.code === categoryOptionCodeForPreventive)
+            )
+            .getOrFail(0);
+
+        const teamReactiveCategoryCombo = _(categoryCombosByCode).getOrFail(
+            baseConfig.categoryComboCodeForTeamReactive
+        );
+
+        const teamPreventiveCategoryCombo = _(categoryCombosByCode).getOrFail(
+            baseConfig.categoryComboCodeForTeamPreventive
+        );
+
+        const defaultCoc = _(defaultCategoryCombo.categoryOptionCombos).getOrFail(0);
+
+        return {
+            reactive: {
+                [defaultCoc.id]: cocForReactive.id,
+                ...this.getMappingForCategoryCombo(metadata, teamReactiveCategoryCombo),
+            },
+            preventive: {
+                [defaultCoc.id]: cocForPreventive.id,
+                ...this.getMappingForCategoryCombo(metadata, teamPreventiveCategoryCombo),
+            },
+        };
+    }
+
+    private getMappingForCategoryCombo(
+        metadata: Metadata,
+        categoryCombo: Metadata["categoryCombos"][number]
+    ): CocMapping {
         const teamCategory = _(metadata.categories)
             .keyBy(cc => cc.code)
             .getOrFail(baseConfig.categoryCodeForTeams);
@@ -159,62 +268,49 @@ class UpdateCampaignsDisaggregation {
         const teamCategoryOptionIds = new Set(teamCategory.categoryOptions.map(co => co.id));
 
         const categoryCombosByCode = _.keyBy(metadata.categoryCombos, cc => cc.code);
-        const campaignTypeCombo = _(categoryCombosByCode).getOrFail(
-            baseConfig.categoryCodeForCampaignType
-        );
-
-        const cocForReactive = _(campaignTypeCombo.categoryOptionCombos)
-            .filter(coc =>
-                _(coc.categoryOptions).some(
-                    co => co.code === baseConfig.categoryOptionCodeForReactive
-                )
-            )
-            .getOrFail(0);
 
         const teamCategoryCombo = _(categoryCombosByCode).getOrFail(
             baseConfig.categoryComboCodeForTeams
         );
 
-        const teamReactiveCategoryCombo = _(categoryCombosByCode).getOrFail(
-            baseConfig.categoryComboCodeForTeamReactive
-        );
-
-        const defaultCoc = _(defaultCategoryCombo.categoryOptionCombos).getOrFail(0);
-
-        debug("Create teamReactiveCategoryCombo mapping");
-        const mapping1: Record<CategoryOptionId, CocId> = _(
-            teamReactiveCategoryCombo.categoryOptionCombos
+        const categoryOptionMapping: Record<CategoryOptionId, CocId> = _(
+            categoryCombo.categoryOptionCombos
         )
             .map(coc => {
                 const teamCategoryOption = coc.categoryOptions.find(co =>
                     teamCategoryOptionIds.has(co.id)
                 );
                 if (!teamCategoryOption) throw new Error();
-                return [teamCategoryOption.id, coc.id] as [Id, Id];
+                return [teamCategoryOption.id, coc.id] as [CategoryOptionId, CocId];
             })
             .fromPairs()
             .value();
 
-        debug("Create teamCategoryCombo mapping");
-        const mapping2 = _(teamCategoryCombo.categoryOptionCombos)
+        const categoryComboMapping = _(teamCategoryCombo.categoryOptionCombos)
             .map(coc => {
                 const categoryOption = _.first(coc.categoryOptions);
-                if (!categoryOption) throw new Error();
-                const teamReactiveCocId = _(mapping1).getOrFail(categoryOption.id);
+                if (!categoryOption) throw new Error("Category options empty");
+                const teamReactiveCocId = _(categoryOptionMapping).getOrFail(categoryOption.id);
                 return [coc.id, teamReactiveCocId] as [CocId, CocId];
             })
             .compact()
             .fromPairs()
             .value();
 
-        return {
-            [defaultCoc.id]: cocForReactive.id,
-            ...mapping2,
-        };
+        return categoryComboMapping;
     }
 }
 
 const metadataQuery = {
+    dataSets: {
+        fields: { id: true, name: true, organisationUnits: { id: true } },
+    },
+    dataElements: {
+        fields: { id: true, name: true },
+    },
+    organisationUnits: {
+        fields: { id: true, name: true },
+    },
     dataElementGroups: {
         fields: { id: true, code: true },
     },
@@ -228,6 +324,7 @@ const metadataQuery = {
             code: true,
             categoryOptionCombos: {
                 id: true,
+                name: true,
                 categoryOptions: { id: true, code: true },
             },
         },
@@ -236,12 +333,21 @@ const metadataQuery = {
 
 type Metadata = MetadataPick<typeof metadataQuery>;
 
-function debug(msg: string) {
-    process.stderr.write(msg + "\n");
-}
-
 type CocId = Id;
 type CategoryOptionId = Id;
+type CocMapping = Record<CocId, CocId>;
+type CampaignCocMapping = { reactive: CocMapping; preventive: CocMapping };
+
+type Attr = "orgUnit" | "dataElement" | "period" | "value" | "type" | "fromAoc" | "toAoc";
+type ReportRow = Record<Attr, string>;
+
+const byId = <T extends NamedRef>(objs: T[]) => _.fromPairs(objs.map(o => [o.id, o] as [Id, T]));
+
+const formatObj = (obj: NamedRef) => `${obj.name.trim()} [${obj.id}]`;
+
+function debug(msg: string) {
+    console.debug(msg);
+}
 
 function padDigits(number: number, digits: number) {
     return Array(Math.max(digits - String(number).length + 1, 0)).join("0") + number;

--- a/src/scripts/tasks.ts
+++ b/src/scripts/tasks.ts
@@ -1,0 +1,257 @@
+import _ from "lodash";
+import fs from "fs";
+import path from "path";
+import { command, run, string, option, subcommands, Type, flag } from "cmd-ts";
+import { D2Api, DataValueSetsDataValue, Id, MetadataPick } from "@eyeseetea/d2-api/2.36";
+import { baseConfig } from "../models/config";
+
+function main() {
+    const updateDataValuesDisaggregation = command({
+        name: "Update data values disaggregation",
+        description:
+            "Update disaggregation (preventive/reactive) for data values (vaccination and population)",
+        args: {
+            url: option({
+                type: string,
+                long: "url",
+                description: "DHIS2 Instance URL: http://USERNAME:PASSWORD@HOST:PORT",
+            }),
+            orgUnitsIds: option({
+                type: StringsSeparatedByCommas,
+                long: "org-units-ids",
+                description: "Organisation units roots (comma-separated IDs)",
+            }),
+            outputPath: option({
+                type: string,
+                long: "output-path",
+                description: "Output path with data values JSON",
+            }),
+            post: flag({
+                long: "post",
+                description: "Post data values",
+            }),
+            postDryRun: flag({
+                long: "post-dry-run",
+                description: "Post data values with dryRun enabled",
+            }),
+        },
+        handler: async args => {
+            const api = getD2Api(args.url);
+            await new UpdateCampaignsDisaggregation(api, args).execute();
+        },
+    });
+
+    const mainCmd = subcommands({
+        name: path.basename(__filename),
+        cmds: {
+            "update-datavalues-disaggregation": updateDataValuesDisaggregation,
+        },
+    });
+
+    run(mainCmd, process.argv.slice(2));
+}
+
+const StringsSeparatedByCommas: Type<string, string[]> = {
+    async from(str) {
+        return str.split(",");
+    },
+};
+
+interface Options {
+    orgUnitsIds: Id[];
+    outputPath: string;
+    post: boolean;
+    postDryRun: boolean;
+}
+
+class UpdateCampaignsDisaggregation {
+    constructor(private api: D2Api, private options: Options) {}
+
+    async execute() {
+        const { api, options } = this;
+        const metadata = await api.metadata.get(metadataQuery).getData();
+        const aocMapping = this.getAoCMapping(metadata);
+        const dataValues = await this.getDataValues(metadata);
+        const dataValuesWithAocMapped = this.getMappedDataValues(dataValues, aocMapping);
+        debug(`Mapped: ${dataValues.length} -> ${dataValuesWithAocMapped.length}`);
+
+        await this.persistDataValues(dataValuesWithAocMapped, options, api);
+    }
+
+    private async persistDataValues(
+        dataValuesWithAocMapped: DataValueSetsDataValue[],
+        options: Options,
+        api: D2Api
+    ) {
+        const groups = _.chunk(dataValuesWithAocMapped, 100000);
+
+        for (const [index, dataValuesGroup] of groups.entries()) {
+            const payload = { dataValues: dataValuesGroup };
+            const json = JSON.stringify(payload, null, 4);
+            const paddedIndex = padDigits(index, 4);
+            const outputPath = options.outputPath.replace(/\.json$/, `-${paddedIndex}.json`);
+            fs.writeFileSync(outputPath, json);
+            debug(`Written [${index + 1}/${groups.length}]: ${outputPath}`);
+
+            if (options.post) {
+                debug(`Post data values: ${dataValuesGroup.length}`);
+                const res = await api.dataValues
+                    .postSet({ skipAudit: true, force: true, dryRun: options.postDryRun }, payload)
+                    .getData();
+                debug(`Response: ${res.status} - ${JSON.stringify(res.importCount)}`);
+            }
+        }
+    }
+
+    private getMappedDataValues(
+        dataValues: DataValueSetsDataValue[],
+        aocMapping: Record<string, string>
+    ) {
+        return _(dataValues)
+            .map(
+                (dataValue): DataValueSetsDataValue | undefined => {
+                    const attributeOptionComboMapped = aocMapping[dataValue.attributeOptionCombo];
+
+                    if (!attributeOptionComboMapped) {
+                        const msg = `Cannot map aoc: ${dataValue.attributeOptionCombo}`;
+                        debug(msg);
+                    } else {
+                        return {
+                            ...dataValue,
+                            attributeOptionCombo: attributeOptionComboMapped,
+                        };
+                    }
+                }
+            )
+            .compact()
+            .value();
+    }
+
+    private async getDataValues(metadata: Metadata): Promise<DataValueSetsDataValue[]> {
+        const dataElementGroupAll = _(metadata.dataElementGroups)
+            .keyBy(deg => deg.code)
+            .getOrFail(baseConfig.dataElementGroupCodeForAntigens);
+
+        debug("Get data values");
+        const { dataValues } = await this.api.dataValues
+            .getSet({
+                orgUnit: this.options.orgUnitsIds,
+                children: true,
+                dataSet: [],
+                dataElementGroup: [dataElementGroupAll.id],
+                startDate: "1970",
+                endDate: (new Date().getFullYear() + 1).toString(),
+            })
+            .getData();
+
+        return dataValues;
+    }
+
+    getAoCMapping(metadata: Metadata): Record<CocId, CocId> {
+        const defaultCategoryCombo = _(metadata.categoryCombos)
+            .keyBy(cc => cc.name)
+            .getOrFail("default");
+
+        const teamCategory = _(metadata.categories)
+            .keyBy(cc => cc.code)
+            .getOrFail(baseConfig.categoryCodeForTeams);
+
+        const teamCategoryOptionIds = new Set(teamCategory.categoryOptions.map(co => co.id));
+
+        const categoryCombosByCode = _.keyBy(metadata.categoryCombos, cc => cc.code);
+        const campaignTypeCombo = _(categoryCombosByCode).getOrFail(
+            baseConfig.categoryCodeForCampaignType
+        );
+
+        const cocForReactive = _(campaignTypeCombo.categoryOptionCombos)
+            .filter(coc =>
+                _(coc.categoryOptions).some(
+                    co => co.code === baseConfig.categoryOptionCodeForReactive
+                )
+            )
+            .getOrFail(0);
+
+        const teamCategoryCombo = _(categoryCombosByCode).getOrFail(
+            baseConfig.categoryComboCodeForTeams
+        );
+
+        const teamReactiveCategoryCombo = _(categoryCombosByCode).getOrFail(
+            baseConfig.categoryComboCodeForTeamReactive
+        );
+
+        const defaultCoc = _(defaultCategoryCombo.categoryOptionCombos).getOrFail(0);
+
+        debug("Create teamReactiveCategoryCombo mapping");
+        const mapping1: Record<CategoryOptionId, CocId> = _(
+            teamReactiveCategoryCombo.categoryOptionCombos
+        )
+            .map(coc => {
+                const teamCategoryOption = coc.categoryOptions.find(co =>
+                    teamCategoryOptionIds.has(co.id)
+                );
+                if (!teamCategoryOption) throw new Error();
+                return [teamCategoryOption.id, coc.id] as [Id, Id];
+            })
+            .fromPairs()
+            .value();
+
+        debug("Create teamCategoryCombo mapping");
+        const mapping2 = _(teamCategoryCombo.categoryOptionCombos)
+            .map(coc => {
+                const categoryOption = _.first(coc.categoryOptions);
+                if (!categoryOption) throw new Error();
+                const teamReactiveCocId = _(mapping1).getOrFail(categoryOption.id);
+                return [coc.id, teamReactiveCocId] as [CocId, CocId];
+            })
+            .compact()
+            .fromPairs()
+            .value();
+
+        return {
+            [defaultCoc.id]: cocForReactive.id,
+            ...mapping2,
+        };
+    }
+}
+
+const metadataQuery = {
+    dataElementGroups: {
+        fields: { id: true, code: true },
+    },
+    categories: {
+        fields: { id: true, code: true, categoryOptions: true },
+    },
+    categoryCombos: {
+        fields: {
+            id: true,
+            name: true,
+            code: true,
+            categoryOptionCombos: {
+                id: true,
+                categoryOptions: { id: true, code: true },
+            },
+        },
+    },
+} as const;
+
+type Metadata = MetadataPick<typeof metadataQuery>;
+
+function debug(msg: string) {
+    process.stderr.write(msg + "\n");
+}
+
+type CocId = Id;
+type CategoryOptionId = Id;
+
+function padDigits(number: number, digits: number) {
+    return Array(Math.max(digits - String(number).length + 1, 0)).join("0") + number;
+}
+
+function getD2Api(baseUrl: string): D2Api {
+    const url = new URL(baseUrl);
+    const decode = decodeURIComponent;
+    const auth = { username: decode(url.username), password: decode(url.password) };
+    return new D2Api({ baseUrl: url.origin + url.pathname, auth });
+}
+
+main();

--- a/tsconfig-cli.json
+++ b/tsconfig-cli.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "es2015",
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "preserve",
+        "noUnusedParameters": false,
+        "noUnusedLocals": false,
+        "experimentalDecorators": true,
+        "lib": ["dom", "dom.iterable", "esnext"]
+    },
+    "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,6 +3861,11 @@ csstype@^2.0.0, csstype@^2.2.0, csstype@^2.5.2:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.1.tgz#4cfbf637a577497036ebcd7e32647ef19a0b8076"
 
+csv-writer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/csv-writer/-/csv-writer-1.6.0.tgz#d0cea44b6b4d7d3baa2ecc6f3f7209233514bcf9"
+  integrity sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.5.4":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -1100,6 +1107,14 @@
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.4.tgz#8fbd113f56699b9832a401e1cb8f54d75bc36b9a"
   dependencies:
     i18next "^10.3"
+
+"@dhis2/d2-i18n@^1.0.5":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.0.tgz#ec777c5091f747e4c5aa4f9801c62ba4d1ef3d16"
+  integrity sha512-x3u58goDQsMfBzy50koxNrJjofJTtjRZOfz6f6Py/wMMJfp/T6vZjWMQgcfWH0JrV6d04K1RTt6bI05wqsVQvg==
+  dependencies:
+    i18next "^10.3"
+    moment "^2.24.0"
 
 "@dhis2/d2-ui-app@^2.0.0":
   version "2.0.0"
@@ -1235,6 +1250,35 @@
     prop-types "^15.5.10"
     recompose "^0.26.0"
     rxjs "^5.5.7"
+
+"@eyeseetea/d2-api@^1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.13.1.tgz#c630cb26a9bcb69f3970129bed6ff34d7b4012c2"
+  integrity sha512-7YnwHDJTeqwfqam7kZR+pam4o7jaYX64pQnH3xI677G/tYT1sVvzEDiTK0GmHIS0zW2ViFxCV8htRBUZhOp6ng==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@dhis2/d2-i18n" "^1.0.5"
+    "@types/prettier" "^1.18.3"
+    "@types/qs" "^6.5.3"
+    abort-controller "3.0.0"
+    argparse "^2.0.1"
+    axios "0.19.2"
+    axios-debug-log "^0.6.2"
+    axios-mock-adapter "1.18.2"
+    btoa "^1.2.1"
+    cronstrue "^1.81.0"
+    cryptr "^4.0.2"
+    d2 "^31.8.1"
+    dotenv "^8.0.0"
+    express "^4.17.1"
+    iconv-lite "0.6.2"
+    isomorphic-fetch "3.0.0"
+    lodash "^4.17.15"
+    log4js "^4.5.1"
+    node-schedule "^1.3.2"
+    qs "^6.9.0"
+    react "^16.12.0"
+    yargs "^14.0.0"
 
 "@material-ui/core@^3.3.1", "@material-ui/core@^3.9.1":
   version "3.9.1"
@@ -1375,6 +1419,13 @@
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.7.tgz#fb68cc9be8487e6ea5b13700e759bfbab7e0fefd"
 
+"@types/debug@^4.0.0":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/http-proxy@^1.17.5":
   version "1.17.8"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.8.tgz#968c66903e7e42b483608030ee85800f22d03f55"
@@ -1422,6 +1473,11 @@
   version "2.2.44"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.44.tgz#1d4a798e53f35212fd5ad4d04050620171cd5b5e"
 
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
 "@types/node@*":
   version "10.12.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
@@ -1430,9 +1486,19 @@
   version "10.12.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.19.tgz#ca1018c26be01f07e66ac7fefbeb6407e4490c61"
 
+"@types/prettier@^1.18.3":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
+  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+
 "@types/prop-types@*":
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
+
+"@types/qs@^6.5.3":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
 "@types/react-dom@^16.0.11":
   version "16.0.11"
@@ -1647,12 +1713,27 @@ abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+abort-controller@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
     mime-types "~2.1.18"
     negotiator "0.6.1"
+
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
@@ -1807,6 +1888,16 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1816,6 +1907,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 ansicolors@~0.3.2:
   version "0.3.2"
@@ -1863,11 +1961,21 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.10, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^3.0.0:
   version "3.0.0"
@@ -2031,6 +2139,13 @@ async@^2.1.4, async@^2.5.0:
   dependencies:
     lodash "^4.17.10"
 
+async@^2.6.2:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2061,6 +2176,29 @@ aws-sign2@~0.7.0:
 aws4@^1.6.0, aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+
+axios-debug-log@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/axios-debug-log/-/axios-debug-log-0.6.2.tgz#c7761ced8f1990e6d48c556b517af8e00edcef31"
+  integrity sha512-aavexsFWw+T09e9JkbsNe/zLjdG4r2vwhnKUtCNC/0wpogI/i+bQWJ0jJIuXof734dQ43uiOiFPgbRu8EVa64Q==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+
+axios-mock-adapter@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.18.2.tgz#01fa9e88e692e8f1bbc1ad1200dde672486e03c7"
+  integrity sha512-e5aTsPy2Viov22zNpFTlid76W1Scz82pXeEwwCXdtO85LROhHAF8pHF2qDhiyMONLxKyY3lQ+S4UCsKgrlx8Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    is-buffer "^2.0.3"
+
+axios@0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 axios@^0.19.0:
   version "0.19.0"
@@ -2417,6 +2555,24 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+body-parser@1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
+  integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.10.3"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -2592,6 +2748,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -2643,6 +2804,11 @@ byte-size@^5.0.1:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cacache@^10.0.4:
   version "10.0.4"
@@ -2719,6 +2885,14 @@ cachedir@1.3.0:
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.3.0.tgz#5e01928bf2d95b5edd94b0942188246740e0dbc4"
   dependencies:
     os-homedir "^1.0.1"
+
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 call-limit@~1.1.0:
   version "1.1.0"
@@ -2838,6 +3012,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 change-emitter@^0.1.2:
   version "0.1.6"
@@ -3002,6 +3184,15 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -3063,6 +3254,16 @@ cmd-shim@^2.0.2, cmd-shim@~2.0.2:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
 
+cmd-ts@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/cmd-ts/-/cmd-ts-0.11.0.tgz#80926180f39665e35e321b72439f792a2b63b745"
+  integrity sha512-6RvjD+f9oGPeWoMS53oavafmQ9qC839PjP3CyvPkAIfqMEXTbrclni7t3fnyVJFNWxuBexnLshcotY0RuNrI8Q==
+  dependencies:
+    chalk "^4.0.0"
+    debug "^4.3.4"
+    didyoumean "^1.2.2"
+    strip-ansi "^6.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -3090,11 +3291,18 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
 
@@ -3274,6 +3482,13 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
+content-disposition@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -3291,6 +3506,11 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+cookie@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3378,6 +3598,24 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron-parser@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.18.0.tgz#de1bb0ad528c815548371993f81a54e5a089edcf"
+  integrity sha512-s4odpheTyydAbTBQepsqd2rNWGa2iV3cyo8g7zbI2QQYGLVsfbhmwukayS1XHppe02Oy1fg7mg6xoaraVJeEcg==
+  dependencies:
+    is-nan "^1.3.0"
+    moment-timezone "^0.5.31"
+
+cronstrue@^1.81.0:
+  version "1.125.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-1.125.0.tgz#8030816d033d00caade9b2a9f9b71e69175bcf42"
+  integrity sha512-qkC5mVbVGuuyBVXmam5anaRtbLcgfBUKajoyZqCdf/XBdgF43PsLSEm8eEi2dsI3YbqDPbLSH2mWNzM1dVqHgQ==
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3422,6 +3660,11 @@ crypto-browserify@^3.11.0:
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
+cryptr@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cryptr/-/cryptr-4.0.2.tgz#8a93b5ca7667d1a6131e396bab23a134ff1f5dc6"
+  integrity sha512-gLTcYjmLGe0Kk1yyacvjNKvSdkWBNNgG2tDnbRQP7yE559x/RJLo/I3WAmwCXNXf/fzMHCNp9vDv3PCopZDpXw==
 
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
@@ -3744,6 +3987,13 @@ d2@^31.1.1:
   dependencies:
     isomorphic-fetch "^2.2.1"
 
+d2@^31.8.1:
+  version "31.10.2"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.10.2.tgz#93023171a703ad37dedf273b07e9643155e42466"
+  integrity sha512-kW/2DKv567foH9JNEBtebfOW6gdmHzNd5dsvA7m8aVK0IZAXYd++lKKqmTUPzpjSRHuM7oUAnTw29/a5JIdfWQ==
+  dependencies:
+    isomorphic-fetch "^2.2.1"
+
 d2@~31.4:
   version "31.4.0"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.4.0.tgz#761e297d0f6a5b4b1d6043de176d887ee5faa09b"
@@ -3780,6 +4030,11 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
 
+date-format@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
+  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -3805,6 +4060,20 @@ debug@^3.1.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
     ms "^2.1.1"
+
+debug@^3.2.6:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.0.0, debug@^4.1.1, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
@@ -3875,6 +4144,14 @@ define-properties@^1.1.2:
   dependencies:
     object-keys "^1.0.12"
 
+define-properties@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -3925,6 +4202,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -3935,6 +4217,11 @@ des.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+
+destroy@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -3976,9 +4263,19 @@ dezalgo@^1.0.0, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
+didyoumean@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
+  integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
+
 diff@^3.2.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -4131,6 +4428,11 @@ dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
 
+dotenv@^8.0.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -4195,7 +4497,7 @@ emoji-regex@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
-emoji-regex@^7.0.2:
+emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
 
@@ -4663,6 +4965,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -4821,6 +5128,43 @@ express@^4.16.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+express@^4.17.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
+  integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.20.0"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.5.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.2.0"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.10.3"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.18.0"
+    serve-static "1.15.0"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -4889,6 +5233,11 @@ fast-deep-equal@^1.0.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^2.0.2:
   version "2.2.6"
@@ -5033,6 +5382,19 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
+finalhandler@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
+  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    statuses "2.0.1"
+    unpipe "~1.0.0"
+
 find-cache-dir@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
@@ -5095,6 +5457,11 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flatted@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -5170,6 +5537,11 @@ form-data@~2.3.1, form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -5217,6 +5589,15 @@ fs-extra@7.0.0, fs-extra@^7.0.0:
 fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -5327,6 +5708,20 @@ gentle-fs@^2.0.0, gentle-fs@^2.0.1:
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
+  integrity sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
@@ -5650,9 +6045,26 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-unicode@^2.0.0, has-unicode@~2.0.1:
   version "2.0.1"
@@ -5866,6 +6278,17 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
 http-parser-js@>=0.4.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
@@ -6006,6 +6429,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -6142,6 +6572,11 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
+inherits@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
@@ -6217,6 +6652,11 @@ ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
 
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
 ipaddr.js@^1.5.2:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.1.tgz#fa4b79fa47fd3def5e3b159825161c0a519c9427"
@@ -6269,6 +6709,11 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
 is-buffer@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+
+is-buffer@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -6432,6 +6877,14 @@ is-installed-globally@0.1.0, is-installed-globally@^0.1.0:
   dependencies:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
+
+is-nan@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 is-negated-glob@^1.0.0:
   version "1.0.0"
@@ -6618,6 +7071,14 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+isomorphic-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
@@ -7786,6 +8247,11 @@ lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
+lodash@^4.17.14, lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -7805,6 +8271,17 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
+log4js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-4.5.1.tgz#e543625e97d9e6f3e6e7c9fc196dd6ab2cae30b5"
+  integrity sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==
+  dependencies:
+    date-format "^2.0.0"
+    debug "^4.1.1"
+    flatted "^2.0.0"
+    rfdc "^1.1.4"
+    streamroller "^1.0.6"
+
 loglevel@^1.4.0, loglevel@^1.4.1, loglevel@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
@@ -7816,6 +8293,11 @@ lolex@^2.3.2:
 lolex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
+
+long-timeout@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
+  integrity sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7867,6 +8349,11 @@ make-dir@^1.0.0:
 make-error@1.x:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-fetch-happen@^4.0.1:
   version "4.0.1"
@@ -8126,6 +8613,11 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 "mime-db@>= 1.36.0 < 2", mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
@@ -8136,9 +8628,21 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
   dependencies:
     mime-db "~1.37.0"
 
+mime-types@~2.1.24, mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.0.3, mime@^2.3.1:
   version "2.3.1"
@@ -8263,9 +8767,21 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment-timezone@^0.5.31:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
+
 moment@2.22.2, moment@^2.22.1:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
+"moment@>= 2.9.0", moment@^2.24.0:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 moment@^2.22.2:
   version "2.24.0"
@@ -8289,6 +8805,16 @@ move-concurrently@^1.0.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
@@ -8371,6 +8897,11 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
 neo-async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
@@ -8409,6 +8940,13 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -8528,6 +9066,15 @@ node-sass@^4.11.0:
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
+
+node-schedule@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-schedule/-/node-schedule-1.3.3.tgz#f8e01c5fb9597f09ecf9c4c25d6938e5e7a06f48"
+  integrity sha512-uF9Ubn6luOPrcAYKfsXWimcJ1tPFtQ8I85wb4T3NgJQrXazEzojcFZVk46ZlLHby3eEJChgkV/0T689IsXh2Gw==
+  dependencies:
+    cron-parser "^2.18.0"
+    long-timeout "0.1.1"
+    sorted-array-functions "^1.3.0"
 
 nomnom@~1.6.2:
   version "1.6.2"
@@ -8861,6 +9408,11 @@ object-inspect@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
 
+object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
@@ -8868,6 +9420,11 @@ object-is@^1.0.1:
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -8934,6 +9491,13 @@ object.values@^1.0.4:
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
+
+on-finished@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -9224,6 +9788,11 @@ parse5@^3.0.1:
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -10061,6 +10630,14 @@ proxy-addr@~2.0.4:
     forwarded "~0.1.2"
     ipaddr.js "1.8.0"
 
+proxy-addr@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -10130,9 +10707,23 @@ qrcode-terminal@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
 
+qs@6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
+qs@^6.9.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
 
 query-string@^6.2.0:
   version "6.4.2"
@@ -10210,6 +10801,11 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
 raw-body@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
@@ -10217,6 +10813,16 @@ raw-body@2.3.3:
     bytes "3.0.0"
     http-errors "1.6.3"
     iconv-lite "0.4.23"
+    unpipe "1.0.0"
+
+raw-body@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
+  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
     unpipe "1.0.0"
 
 raw-loader@^3.1.0:
@@ -10473,6 +11079,15 @@ react-transition-group@^2.2.1, react-transition-group@^2.5.3:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
+react@^16.12.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
 react@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.6.0.tgz#b34761cfaf3e30f5508bc732fb4736730b7da246"
@@ -10712,6 +11327,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
 regenerator-transform@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb"
@@ -10928,6 +11548,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -11026,6 +11651,11 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
 
+rfdc@^1.1.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -11110,13 +11740,18 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
+safe-buffer@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -11257,6 +11892,25 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
+send@0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
+  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "2.4.1"
+    range-parser "~1.2.1"
+    statuses "2.0.1"
+
 serialize-javascript@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
@@ -11281,6 +11935,16 @@ serve-static@1.13.2:
     escape-html "~1.0.3"
     parseurl "~1.3.2"
     send "0.16.2"
+
+serve-static@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
+  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.18.0"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -11311,6 +11975,11 @@ setimmediate@^1.0.4, setimmediate@^1.0.5:
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
@@ -11371,6 +12040,15 @@ shell-quote@1.6.1:
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -11497,6 +12175,11 @@ socks@~2.3.2:
     ip "^1.1.5"
     smart-buffer "4.0.2"
 
+sorted-array-functions@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz#8605695563294dffb2c9796d602bd8459f7a0dd5"
+  integrity sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==
+
 sorted-object@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/sorted-object/-/sorted-object-2.0.1.tgz#7d631f4bd3a798a24af1dffcfbfe83337a5df5fc"
@@ -11533,6 +12216,14 @@ source-map-support@^0.4.15:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
+
+source-map-support@^0.5.17:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6:
   version "0.5.9"
@@ -11666,6 +12357,11 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 "statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -11727,6 +12423,17 @@ stream-to-observable@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
+streamroller@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-1.0.6.tgz#8167d8496ed9f19f05ee4b158d9611321b8cacd9"
+  integrity sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==
+  dependencies:
+    async "^2.6.2"
+    date-format "^2.0.0"
+    debug "^3.2.6"
+    fs-extra "^7.0.1"
+    lodash "^4.17.14"
+
 strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
@@ -11752,6 +12459,15 @@ string-width@^1.0.1, string-width@^1.0.2:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
 
 string.prototype.trim@^1.1.2:
   version "1.1.2"
@@ -11794,6 +12510,20 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -11862,6 +12592,13 @@ supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-co
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 svgo@^1.0.0, svgo@^1.0.5:
   version "1.1.1"
@@ -12134,6 +12871,11 @@ to-through@^2.0.0:
   dependencies:
     through2 "^2.0.3"
 
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 topo@2.x.x:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
@@ -12172,6 +12914,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -12203,6 +12950,18 @@ ts-jest@^23.10.5:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+ts-node@9:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
@@ -12238,6 +12997,14 @@ type-is@~1.6.16:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
+
+type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 typed-html@^1.0.0:
   version "1.0.0"
@@ -12661,6 +13428,11 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -12783,6 +13555,11 @@ whatwg-fetch@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-mimetype@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#a3d58ef10b76009b042d03e25591ece89b88d171"
@@ -12790,6 +13567,14 @@ whatwg-mimetype@^2.1.0:
 whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"
@@ -12966,6 +13751,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -13057,6 +13851,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.1:
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.3.tgz#316e263d5febe8b38eef61ac092b33dfcc9b1115"
+  integrity sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -13120,6 +13922,23 @@ yargs@^12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
+yargs@^14.0.0:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.1"
+
 yargs@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
@@ -13150,3 +13969,8 @@ yauzl@2.8.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/23nep74

- [x] Update dashboards
- [x] Upload new metadata: https://github.com/EyeSeeTea/vaccination-app/tree/feature/preventive-campaigns-23nep74/metadata
- [x] Script to tag dataValues with new attribute option combo.

### :memo: Implementation

- Added separate category combos for preventive/reactive.

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?

```
$ yarn tasks update-datavalues-disaggregation --url='http://admin:PASSWORD@'localhost:8080 --org-units-ids=zOyMxdCLXBM --output-path=datavalues.json
```

Add --post to actually save the data values. For each existing data values, there is a deletion (with old attributeOptionCombo) + creation (with new attributeOptionCombo).

Script: DB 20220609T030003Z.dump.sql -> you'll get a warning when creating the mapping for categoryOption`Team NNN - VACCINATION ROUGEOLE KALOLE`, that's because these teams are not assigned to the Team category (_23.4 RVC Teams).