### PR TITLE
Fix team categoryOption match with campaign name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vaccination-app",
     "description": "DHIS2 MSF Reactive Vaccination App",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/models/Teams.ts
+++ b/src/models/Teams.ts
@@ -200,15 +200,22 @@ export function filterTeamsByNames(
     teamCategoryId: string
 ): CategoryOptionTeam[] {
     if (_.isEmpty(teams)) return [];
-
-    const matchers = campaignNames.map(name => new RegExp(`^Team \\d+ - ${name}$`));
+    const nameMatches = (teamName: string, campaignName: string) => {
+        const splitStr = " - ";
+        const campaignNameFromTeam = teamName
+            .split(splitStr)
+            .slice(1)
+            .join(splitStr);
+        const prefixRegexp = new RegExp("^Team \\d+" + splitStr);
+        return Boolean(teamName.match(prefixRegexp) && campaignName === campaignNameFromTeam);
+    };
 
     const filteredTeams = teams.filter(
         (co: { categories: Array<{ id: string }>; name: string }) => {
             const categoryIds = co.categories.map(c => c.id);
             return (
                 _.includes(categoryIds, teamCategoryId) &&
-                matchers.some(matcher => matcher.test(co.name))
+                _(campaignNames).some(campaignName => nameMatches(co.name, campaignName))
             );
         }
     );


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865bap63a

### :memo: Implementation

- The problem manifested when the campaign name used special chars (in this case: `(`, and `)` -> `CV_BAORO (RCA) multiAg Sept/Nov 2022`). 
- Instead of building a matching regexp, it has been refactored to match the suffix directly by string.
- No changes are required in the DB, the teams were correctly stored, it's just the count get that was failing. (So it was safe to put the correct value and re-save)