### PR TITLE
Update role names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vaccination-app",
     "description": "DHIS2 MSF Reactive Vaccination App",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/models/CampaignSharing.ts
+++ b/src/models/CampaignSharing.ts
@@ -4,6 +4,7 @@ import { OrganisationUnitGroupSet, Access, Sharing } from "./db.types";
 import Campaign from "./campaign";
 import DbD2 from "./db-d2";
 import { promiseMap } from "../utils/promises";
+import { userRoles } from "./config";
 
 /*
     Return sharing object {publicAccess, externalAccess, userAccesses, userGroupAccesses} for
@@ -126,8 +127,12 @@ export default class CampaignSharing {
                     type: "usersByOrgUnits",
                     level: 4,
                     userRoles: [
-                        ["RVC App"],
-                        ["Medical Focal Point", "Field User", "Online Data Entry"],
+                        [userRoles.app],
+                        [
+                            userRoles.medicalFocalPoint,
+                            userRoles.fieldUser,
+                            userRoles.onlineDataEntry,
+                        ],
                     ],
                     permission: { metadata: "edit" },
                 },

--- a/src/models/__tests__/datasets.spec.js
+++ b/src/models/__tests__/datasets.spec.js
@@ -29,6 +29,7 @@ describe("DataSets", () => {
                 await list(metadataConfig, d2, {}, {});
 
                 expect(d2.models.dataSets.list).toHaveBeenCalledWith({
+                    apiEndpoint: "/dataSets",
                     fields: expectedFields.join(","),
                     pageSize: 1000,
                     filter: createdByAppFilters,
@@ -53,6 +54,7 @@ describe("DataSets", () => {
                 await list(metadataConfig, d2, filters, pagination);
 
                 expect(d2.models.dataSets.list).toHaveBeenCalledWith({
+                    apiEndpoint: "/dataSets",
                     fields: expectedFields.join(","),
                     pageSize: 1000,
                     filter: ["displayName:ilike:abc", ...createdByAppFilters],

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -18,12 +18,12 @@ import {
 import { sortAgeGroups } from "../utils/age-groups";
 
 export const userRoles = {
-    app: "RVC App",
-    campaignManager: "RVC Campaign Manager",
-    feedback: "RVC Feedback",
-    fieldUser: "Field User",
-    medicalFocalPoint: "Medical Focal Point",
-    onlineDataEntry: "Online Data Entry",
+    app: "RVC App: Access",
+    campaignManager: "RVC App: Campaign Manager",
+    feedback: "RVC App: Feedback",
+    fieldUser: "Position: Field User",
+    medicalFocalPoint: "Position: Medical Focal Point",
+    onlineDataEntry: "Data Entry: Online Edit",
 };
 
 export const baseConfig = {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -17,6 +17,15 @@ import {
 } from "./db.types";
 import { sortAgeGroups } from "../utils/age-groups";
 
+export const userRoles = {
+    app: "RVC App",
+    campaignManager: "RVC Campaign Manager",
+    feedback: "RVC Feedback",
+    fieldUser: "Field User",
+    medicalFocalPoint: "Medical Focal Point",
+    onlineDataEntry: "Online Data Entry",
+};
+
 export const baseConfig = {
     expirationDays: 8,
     categoryCodeForAntigens: "RVC_ANTIGEN",
@@ -37,9 +46,13 @@ export const baseConfig = {
     dataElementCodeForPopulationByAge: "RVC_POPULATION_BY_AGE",
     dataSetDashboardCodePrefix: "RVC_CAMPAIGN",
     userRoleNames: {
-        manager: ["RVC Campaign Manager"],
-        feedback: ["RVC Feedback"],
-        targetPopulation: ["Medical Focal Point", "Field User", "Online Data Entry"],
+        manager: [userRoles.campaignManager],
+        feedback: [userRoles.feedback],
+        targetPopulation: [
+            userRoles.medicalFocalPoint,
+            userRoles.fieldUser,
+            userRoles.onlineDataEntry,
+        ],
     },
 };
 

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -45,7 +45,7 @@ export async function list(config, d2, filters, pagination) {
         `categoryCombo.code:eq:${config.categoryCodeForTeams}`,
     ]);
     const fields = (forcedFields || defaultListFields).concat(requiredFields).join(",");
-    const listOptions = { fields, filter, pageSize: 1000, order };
+    const listOptions = { fields, filter, pageSize: 1000, order, apiEndpoint: "/dataSets" };
 
     const dataSetsBase = await d2.models.dataSets
         .list(_.pickBy(listOptions, x => _.isNumber(x) || !_.isEmpty(x)))


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865cekarg

### :memo: Implementation

- Centralized all users roles in a single file (config), so renaming is easier.
- Minor change on d2.dataSets.list to make it work in DEV.

```
RVC App  ➝ RVC App: Access
RVC Campaign Manager ➝ RVC App: Campaign Manager
RVC Feedback ➝ RVC App: Feedback
Medical Focal Point ➝ Position: Medical Focal Point
Field User ➝ Position: Field User
Online Data Entry ➝ Data Entry: Online Edit
```