### PR TITLE
Support preventive campaigns

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-05-01T11:17:43.649Z\n"
-"PO-Revision-Date: 2024-05-01T11:17:43.649Z\n"
+"POT-Creation-Date: 2024-05-07T07:43:08.641Z\n"
+"PO-Revision-Date: 2024-05-07T07:43:08.641Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -260,6 +260,12 @@ msgid "Help"
 msgstr ""
 
 msgid "Back"
+msgstr ""
+
+msgid "Reactive"
+msgstr ""
+
+msgid "Preventive"
 msgstr ""
 
 msgid "Disaggregation"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-23T10:31:50.107Z\n"
-"PO-Revision-Date: 2022-03-23T10:31:50.107Z\n"
+"POT-Creation-Date: 2024-05-01T11:17:43.649Z\n"
+"PO-Revision-Date: 2024-05-01T11:17:43.649Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -348,9 +348,6 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-msgid "Value"
-msgstr ""
-
 msgid "Doses administered"
 msgstr ""
 
@@ -358,6 +355,9 @@ msgid "Quality and safety indicators"
 msgstr ""
 
 msgid "General Q&S"
+msgstr ""
+
+msgid "Value"
 msgstr ""
 
 msgid ""

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "eslint-plugin-import": "^2.16.0",
         "eslint-plugin-jsx-a11y": "^6.2.0",
         "eslint-plugin-react": "^7.12.4",
+        "html": "^1.0.0",
         "http-proxy-middleware": "1.3.1",
         "loglevel": "^1.6.1",
         "prettier": "1.16.3",

--- a/src/components/steps/disaggregation/AntigenSection.tsx
+++ b/src/components/steps/disaggregation/AntigenSection.tsx
@@ -2,11 +2,21 @@ import React from "react";
 import _ from "lodash";
 
 import { withStyles } from "@material-ui/core/styles";
-import { Table, TableBody, TableCell, TableHead, TableRow } from "@material-ui/core";
+import {
+    FormControl,
+    FormControlLabel,
+    Radio,
+    RadioGroup,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+} from "@material-ui/core";
 import { createStyles, WithStyles, Theme } from "@material-ui/core";
 
 import i18n from "../../../locales";
-import { AntigenDisaggregation } from "../../../models/AntigensDisaggregation";
+import { AntigenDisaggregation, CampaignType } from "../../../models/AntigensDisaggregation";
 import SimpleCheckbox from "../../forms/SimpleCheckBox";
 import DataElement from "./DataElement";
 import { memoize } from "../../../utils/memoize";
@@ -17,6 +27,7 @@ interface AntigenSectionProps extends WithStyles<typeof styles> {
     antigen: AntigenDisaggregation;
     antigenCode: string;
     update: (path: Path) => (value: any) => void;
+    setCampaignType(type: CampaignType): void;
 }
 
 interface DisaggregationStepState {
@@ -38,7 +49,8 @@ class AntigenSection extends React.Component<AntigenSectionProps, Disaggregation
     });
 
     render() {
-        const { antigen, antigenCode, classes, update } = this.props;
+        const { antigen, antigenCode, classes, update, setCampaignType } = this.props;
+        const { isTypeSelectable } = this.props.antigen;
 
         return (
             <Table className={classes.table}>
@@ -49,6 +61,10 @@ class AntigenSection extends React.Component<AntigenSectionProps, Disaggregation
                 </TableHead>
 
                 <TableBody>
+                    {isTypeSelectable && (
+                        <TypeSelect antigen={antigen} setCampaignType={setCampaignType} />
+                    )}
+
                     {_.flatMap(antigen.dataElements, (dataElement, dataElementIdx) => [
                         <TableRow key={dataElementIdx}>
                             <TableCell component="th" scope="row">
@@ -84,6 +100,48 @@ class AntigenSection extends React.Component<AntigenSectionProps, Disaggregation
                     ])}
                 </TableBody>
             </Table>
+        );
+    }
+}
+
+interface TypeSelectProps {
+    antigen: AntigenDisaggregation;
+    setCampaignType(type: CampaignType): void;
+}
+
+class TypeSelect extends React.Component<TypeSelectProps> {
+    handleOptionChange = (_event: React.ChangeEvent<{}>, value: string) => {
+        if (value === "preventive" || value === "reactive") {
+            this.props.setCampaignType(value);
+        }
+    };
+
+    render() {
+        return (
+            <TableRow>
+                <TableCell component="th" scope="row">
+                    <FormControl>
+                        <RadioGroup
+                            row={true}
+                            aria-label="option"
+                            name="option"
+                            value={this.props.antigen.type}
+                            onChange={this.handleOptionChange}
+                        >
+                            <FormControlLabel
+                                value="reactive"
+                                control={<Radio />}
+                                label={i18n.t("Reactive")}
+                            />
+                            <FormControlLabel
+                                value="preventive"
+                                control={<Radio />}
+                                label={i18n.t("Preventive")}
+                            />
+                        </RadioGroup>
+                    </FormControl>
+                </TableCell>
+            </TableRow>
         );
     }
 }

--- a/src/components/steps/disaggregation/DisaggregationStep.tsx
+++ b/src/components/steps/disaggregation/DisaggregationStep.tsx
@@ -16,6 +16,7 @@ import AntigenSection from "./AntigenSection";
 
 const { Sidebar } = require("@dhis2/d2-ui-core"); // Untyped
 import "./DisaggregationStep.css";
+import { CampaignType } from "../../../models/AntigensDisaggregation";
 
 type Path = (number | string)[];
 
@@ -48,6 +49,15 @@ class DisaggregationStep extends React.Component<DisaggregationStepProps, Disagg
         this.setState({ currentAntigen: antigen });
     };
 
+    setCampaignType = (type: CampaignType): void => {
+        const { campaign, onChange } = this.props;
+        const antigen = this.state.currentAntigen;
+        if (!antigen) return;
+        const updated = campaign.antigensDisaggregation.setCampaignType(antigen, type);
+        const campaignUpdated = campaign.setAntigensDisaggregation(updated);
+        onChange(campaignUpdated);
+    };
+
     render() {
         const { classes, campaign } = this.props;
         const { currentAntigen } = this.state;
@@ -74,6 +84,7 @@ class DisaggregationStep extends React.Component<DisaggregationStepProps, Disagg
                             antigen={currentAntigenDisaggregation}
                             antigenCode={currentAntigen.code}
                             update={this.update}
+                            setCampaignType={this.setCampaignType}
                         />
                     </div>
                 </div>

--- a/src/components/steps/disaggregation/OptionGroup.tsx
+++ b/src/components/steps/disaggregation/OptionGroup.tsx
@@ -26,15 +26,15 @@ const OptionGroup: SFC<OptionGroupProps> = props => {
                 {optionGroup.values[optionGroup.indexSelected].map((option, optionIdx) =>
                     !isEditing ? (
                         option.selected && (
-                            <span key={option.name} className={classes.optionValue}>
-                                {option.name}
+                            <span key={option.option.id} className={classes.optionValue}>
+                                {option.option.displayName}
                             </span>
                         )
                     ) : (
                         <SimpleCheckbox
-                            key={option.name}
+                            key={option.option.id}
                             checked={option.selected}
-                            label={option.name}
+                            label={option.option.displayName}
                             onChange={update([
                                 ...basePath,
                                 "values",
@@ -54,7 +54,7 @@ const OptionGroup: SFC<OptionGroupProps> = props => {
                             value={optionGroup.indexSelected.toString()}
                             onChange={update([...basePath, "indexSelected"])}
                             options={optionGroup.values.map((og, index) => ({
-                                text: og.map(o => o.name).join(" , "),
+                                text: og.map(o => o.option).join(" , "),
                                 value: index.toString(),
                             }))}
                         />

--- a/src/components/steps/save/SaveStep.jsx
+++ b/src/components/steps/save/SaveStep.jsx
@@ -149,7 +149,9 @@ class SaveStep extends React.Component {
             "(",
             `${i18n.t("doses")}: ${antigen.doses.length}`,
             ", ",
-            `${i18n.t("age groups")}: ${ageGroups.join(", ")}`,
+            `${i18n.t("age groups")}: ${ageGroups
+                .map(ageGroup => ageGroup.displayName)
+                .join(", ")}`,
             ")",
         ].join("");
     }

--- a/src/components/target-population/PopulationDistribution.tsx
+++ b/src/components/target-population/PopulationDistribution.tsx
@@ -120,8 +120,8 @@ class PopulationDistributionComponent extends React.Component<PopulationDistribu
                             <TableCell className={classes.orgUnitColumn} />
 
                             {ageGroups.map(ageGroup => (
-                                <TableCell key={ageGroup} className={classes.tableHead}>
-                                    {ageGroup}
+                                <TableCell key={ageGroup.id} className={classes.tableHead}>
+                                    {ageGroup.displayName}
                                 </TableCell>
                             ))}
                             <TableCell className={classes.tableActions}>{/* Actions */}</TableCell>
@@ -134,7 +134,7 @@ class PopulationDistributionComponent extends React.Component<PopulationDistribu
                             antigen={antigen}
                             key={antigen.id}
                             distribution={populationDistribution}
-                            ageGroups={ageGroups}
+                            ageGroups={ageGroups.map(group => group.displayName)}
                         />
 
                         <TableRow className={classes.separatorRow}>

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -63,6 +63,7 @@ export type AntigenDisaggregationCategoriesData = AntigenDisaggregation["dataEle
 export type AntigenDisaggregationOptionGroup = AntigenDisaggregationCategoriesData[0]["options"][0];
 
 export type AntigenDisaggregationEnabled = Array<{
+    type: CampaignType;
     antigen: Antigen;
     ageGroups: Array<CategoryOption>;
     dataElements: Array<{
@@ -299,6 +300,7 @@ export class AntigensDisaggregation {
 
                 return {
                     ageGroups: ageGroups,
+                    type: antigenDisaggregation.type,
                     antigen: {
                         code: antigenDisaggregation.code,
                         name: antigenDisaggregation.name,

--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -128,6 +128,7 @@ export default class CampaignDb {
         const dataSet: DataSet = {
             id: dataSetId,
             name: campaign.name,
+            shortName: campaign.name.slice(0, 50),
             description: campaign.description,
             periodType: "Daily",
             categoryCombo: { id: this.catComboIdForTeams },

--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -6,7 +6,7 @@ import "../utils/lodash-mixins";
 
 import Campaign from "./campaign";
 import { DataSetCustomForm } from "./DataSetCustomForm";
-import { Maybe, MetadataResponse, DataEntryForm, Section } from "./db.types";
+import { Maybe, MetadataResponse, DataEntryForm, Section, CategoryOption } from "./db.types";
 import { Metadata, DataSet, Response } from "./db.types";
 import { getDaysRange, toISOStringNoTZ } from "../utils/date";
 import { getDataElements, CocMetadata } from "./AntigensDisaggregation";
@@ -270,13 +270,14 @@ export default class CampaignDb {
 
             const greyedFields = _(disaggregationData.dataElements)
                 .flatMap(dataElementDis => {
-                    const groups: string[][] = _.cartesianProduct(
+                    const groups: CategoryOption[][] = _.cartesianProduct(
                         dataElementDis.categories.map(category => category.categoryOptions)
                     );
 
-                    return groups.map(group => {
-                        const cocName = group.join(", ");
-                        const cocId = _(cocMetadata.cocIdByName).getOrFail(cocName);
+                    return groups.map(disaggregation => {
+                        const cocId = cocMetadata.getByOptions(disaggregation);
+                        if (!cocId)
+                            throw new Error(`coc not found: ${JSON.stringify(disaggregation)} `);
 
                         return {
                             dataElement: { id: dataElementDis.id },

--- a/src/models/Dashboard.ts
+++ b/src/models/Dashboard.ts
@@ -6,7 +6,13 @@ import {
     itemsMetadataConstructor,
     buildDashboardItems,
 } from "./dashboard-items";
-import { Ref, OrganisationUnitPathOnly, OrganisationUnitWithName, Sharing } from "./db.types";
+import {
+    Ref,
+    OrganisationUnitPathOnly,
+    OrganisationUnitWithName,
+    Sharing,
+    CategoryOption,
+} from "./db.types";
 import { Antigen } from "./campaign";
 import { Moment } from "moment";
 import { getDaysRange } from "../utils/date";
@@ -84,8 +90,8 @@ export class Dashboard {
             .fromPairs()
             .value();
 
-        const ageGroupsToId = (ageGroups: string[]): string[] =>
-            _.map(ageGroups, ag => categoryOptionsByName[ag]);
+        const ageGroupsToId = (ageGroups: CategoryOption[]): string[] =>
+            _.map(ageGroups, ag => categoryOptionsByName[ag.displayName]);
 
         const ageGroupsByAntigen: _.Dictionary<string[]> = _(antigensDisaggregation)
             .map(d => [d.antigen.id, ageGroupsToId(d.ageGroups)])

--- a/src/models/DataSetCustomForm.ts
+++ b/src/models/DataSetCustomForm.ts
@@ -1,10 +1,10 @@
 import { MetadataConfig } from "./config";
 import _ from "lodash";
 const { createElement } = require("typed-html");
+import i18n from "@dhis2/d2-i18n";
 
 import Campaign, { Antigen } from "./campaign";
 import { AntigenDisaggregationEnabled, CocMetadata } from "./AntigensDisaggregation";
-import i18n from "../locales";
 import "../utils/lodash-mixins";
 import { CategoryOption, getCode, getId } from "./db.types";
 
@@ -120,11 +120,6 @@ export class DataSetCustomForm {
         categoryOptionGroups: CategoryOption[][]
     ): CategoryOption[][] {
         if (!antigen) return categoryOptionGroups;
-
-        const categoryType = this.config.categories.find(
-            category => category.code === this.config.categoryCodeForType
-        )!;
-        if (!categoryType) throw new Error("categoryType not found");
 
         const disaggregation = this.campaign.antigensDisaggregation.forAntigen(antigen);
         if (!disaggregation) return categoryOptionGroups;
@@ -416,7 +411,17 @@ export class DataSetCustomForm {
         const generalDataElements = this.getGeneralDataElements(disaggregations);
 
         const tabs = _.compact([
-            ...disaggregations.map(({ antigen }) => ({ name: antigen.name, id: antigen.id })),
+            ...disaggregations.map(disaggregation => {
+                const { antigen } = disaggregation;
+
+                const type =
+                    disaggregation.type === "preventive"
+                        ? i18n.t("Preventive")
+                        : i18n.t("Reactive");
+
+                const name = `[${type}] ${antigen.name}`;
+                return { name: name, id: antigen.id };
+            }),
             !_(generalDataElements).isEmpty()
                 ? { name: i18n.t("General Q&S"), id: this.generalIndicatorsTabId }
                 : null,

--- a/src/models/__tests__/DataSetCustomForm.spec.ts
+++ b/src/models/__tests__/DataSetCustomForm.spec.ts
@@ -1,0 +1,59 @@
+import { renderHeaderForGroup } from "../DataSetCustomForm";
+import { co } from "./config-mock";
+// @ts-ignore
+import { prettyPrint } from "html";
+
+describe("renderHeaderForGroup", () => {
+    it("should return the correct header for the group", () => {
+        const rows = renderHeaderForGroup(
+            [
+                [co("1y"), co("Male"), co("Host")],
+                [co("1y"), co("Male"), co("Refugee")],
+                [co("1y"), co("Female"), co("Host")],
+                [co("5y"), co("Male"), co("Host")],
+                [co("5y"), co("Female"), co("Refugee")],
+            ],
+            false
+        );
+
+        const [row1, row2, row3] = rows;
+
+        expect(rows.length).toBe(3);
+
+        const expectedRow1 = `<tr>
+            <td class="header-first-column"></td>
+            <th colspan="3" scope="col" class="data-header" data-translate><span align="center">1y</span></th>
+            <th colspan="2" scope="col" class="data-header" data-translate><span align="center">5y</span></th>
+            <th rowspan="3" class="data-header" data-translate><span align="center">Total</span></th>
+        </tr>`;
+
+        const expectedRow2 = `<tr>
+            <td class="header-first-column"></td>
+            <th colspan="2" scope="col" class="data-header" data-translate><span align="center">Male</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Female</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Male</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Female</span></th>
+        </tr>`;
+
+        const expectedRow3 = `<tr>
+            <td class="header-first-column"></td>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Host</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Refugee</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Host</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Host</span></th>
+            <th colspan="1" scope="col" class="data-header" data-translate><span align="center">Refugee</span></th>
+        </tr>`;
+
+        expectSameHtml(row1, expectedRow1);
+        expectSameHtml(row2, expectedRow2);
+        expectSameHtml(row3, expectedRow3);
+    });
+});
+
+function expectSameHtml(html1: string, html2: string): void {
+    const html1p = prettyPrint(html1);
+    const html2p = prettyPrint(html2);
+    expect(html1p).toEqual(html2p);
+}
+
+export {};

--- a/src/models/__tests__/config-mock.ts
+++ b/src/models/__tests__/config-mock.ts
@@ -1,7 +1,7 @@
 import { MetadataConfig, baseConfig } from "../config";
 import { CategoryOption } from "../db.types";
 
-function co(name: string): CategoryOption {
+export function co(name: string): CategoryOption {
     return {
         id: `id-${name}`,
         code: name,
@@ -195,53 +195,57 @@ const metadataConfig: MetadataConfig = {
             id: "1",
             name: "Vaccine doses administered",
             code: "RVC_DOSES_ADMINISTERED",
-            categories: [
-                { code: "RVC_AGE_GROUP", optional: false },
-                { code: "RVC_GENDER", optional: true },
-                { code: "RVC_DISPLACEMENT_STATUS", optional: true },
-            ],
+            categories: {
+                RVC_ANTIGEN_MEASLES: [
+                    { code: "RVC_AGE_GROUP", optional: false },
+                    { code: "RVC_GENDER", optional: true },
+                    { code: "RVC_DISPLACEMENT_STATUS", optional: true },
+                ],
+            },
         },
         {
             id: "2",
             name: "Vaccine doses used",
             code: "RVC_USED",
-            categories: [],
+            categories: {},
         },
         {
             id: "3",
             name: "ADS used",
             code: "RVC_ADS_USED",
-            categories: [],
+            categories: {},
         },
         {
             id: "4",
             name: "Syringes for dilution",
             code: "RVC_SYRINGES",
-            categories: [],
+            categories: {},
         },
         {
             id: "5",
             name: "Needles doses used",
             code: "RVC_NEEDLES",
-            categories: [],
+            categories: {},
         },
         {
             id: "6",
             name: "Safety boxes",
             code: "RVC_SAFETY_BOXES",
-            categories: [],
+            categories: {},
         },
         {
             id: "7",
             name: "Accidental Exposure to Blood (AEB)",
             code: "RVC_AEB",
-            categories: [],
+            categories: {},
         },
         {
             id: "8",
             name: "Adverse Event Following Immunization",
             code: "RVC_AEFI",
-            categories: [{ code: "RVC_SEVERITY", optional: true }],
+            categories: {
+                RVC_ANTIGEN_MEASLES: [{ code: "RVC_SEVERITY", optional: true }],
+            },
         },
     ],
     antigens: [

--- a/src/models/__tests__/config-mock.ts
+++ b/src/models/__tests__/config-mock.ts
@@ -271,6 +271,7 @@ const metadataConfig: MetadataConfig = {
                 [[co("12 - 59 m")], [co("12 - 23 m"), co("24 - 59 m")]],
                 [[co("5 - 14 y")], [co("5 - 9 y"), co("5 - 12 y")]],
             ],
+            isTypeSelectable: false,
         },
         {
             id: "2",
@@ -289,9 +290,11 @@ const metadataConfig: MetadataConfig = {
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
             ageGroups: [[[co("2 - 4 y")]], [[co("5 - 14 y")]], [[co("15 - 29 y")]]],
+            isTypeSelectable: false,
         },
         {
             id: "3",
+            isTypeSelectable: false,
             name: "Meningitis Conjugate",
             displayName: "Meningitis Conjugate",
             code: "RVC_MENCONJ",
@@ -314,6 +317,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "4",
+            isTypeSelectable: false,
             name: "Cholera",
             displayName: "Cholera",
             code: "RVC_CHOLERA",
@@ -331,6 +335,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "5",
+            isTypeSelectable: false,
             name: "PCV",
             displayName: "PCV",
             code: "RVC_PCV",
@@ -352,6 +357,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "6",
+            isTypeSelectable: false,
             name: "Pertussis Penta",
             displayName: "Pertussis Penta",
             code: "RVC_PERTPENTA",
@@ -373,6 +379,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "7",
+            isTypeSelectable: false,
             name: "Yellow Fever",
             displayName: "Yellow Fever",
             code: "RVC_YELLOW_FEVER",
@@ -401,6 +408,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "8",
+            isTypeSelectable: false,
             name: "Japanese Encephalitis",
             displayName: "Japanese Encephalitis",
             code: "RVC_JPENC",
@@ -424,6 +432,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "9",
+            isTypeSelectable: false,
             name: "Dengue",
             displayName: "Dengue",
             code: "RVC_DENGUE",
@@ -442,6 +451,7 @@ const metadataConfig: MetadataConfig = {
         },
         {
             id: "10",
+            isTypeSelectable: false,
             name: "Typhoid Fever",
             displayName: "Typhoid Fever",
             code: "RVC_TYPHOID_FEVER",

--- a/src/models/__tests__/config-mock.ts
+++ b/src/models/__tests__/config-mock.ts
@@ -1,4 +1,14 @@
 import { MetadataConfig, baseConfig } from "../config";
+import { CategoryOption } from "../db.types";
+
+function co(name: string): CategoryOption {
+    return {
+        id: `id-${name}`,
+        code: name,
+        name: name,
+        displayName: name,
+    };
+}
 
 const metadataConfig: MetadataConfig = {
     ...baseConfig,
@@ -53,7 +63,7 @@ const metadataConfig: MetadataConfig = {
             dataDimension: true,
             $categoryOptions: {
                 kind: "values",
-                values: ["Team 1", "Team 2", "Team 3", "Team 4", "Team 5"],
+                values: [co("Team 1"), co("Team 2"), co("Team 3"), co("Team 4"), co("Team 5")],
             },
         },
         {
@@ -61,21 +71,21 @@ const metadataConfig: MetadataConfig = {
             code: "RVC_GENDER",
             dataDimensionType: "DISAGGREGATION",
             dataDimension: true,
-            $categoryOptions: { kind: "values", values: ["Female", "Male"] },
+            $categoryOptions: { kind: "values", values: [co("Female"), co("Male")] },
         },
         {
             name: "Severity",
             code: "RVC_SEVERITY",
             dataDimensionType: "DISAGGREGATION",
             dataDimension: true,
-            $categoryOptions: { kind: "values", values: ["Minor", "Severe"] },
+            $categoryOptions: { kind: "values", values: [co("Minor"), co("Severe")] },
         },
         {
             name: "Displacement Status",
             code: "RVC_DISPLACEMENT_STATUS",
             dataDimensionType: "DISAGGREGATION",
             dataDimension: true,
-            $categoryOptions: { kind: "values", values: ["Host", "IDP", "Refugees"] },
+            $categoryOptions: { kind: "values", values: [co("Host"), co("IDP"), co("Refugees")] },
         },
         {
             name: "Demographic age distribution",
@@ -237,6 +247,7 @@ const metadataConfig: MetadataConfig = {
     antigens: [
         {
             id: "1",
+            displayName: "Measles",
             name: "Measles",
             code: "RVC_MEASLES",
             doses: [],
@@ -251,15 +262,16 @@ const metadataConfig: MetadataConfig = {
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
             ageGroups: [
-                [["6 - 8 m"]],
-                [["9 - 11 m"]],
-                [["12 - 59 m"], ["12 - 23 m", "24 - 59 m"]],
-                [["5 - 14 y"], ["5 - 9 y", "5 - 12 y"]],
+                [[co("6 - 8 m")]],
+                [[co("9 - 11 m")]],
+                [[co("12 - 59 m")], [co("12 - 23 m"), co("24 - 59 m")]],
+                [[co("5 - 14 y")], [co("5 - 9 y"), co("5 - 12 y")]],
             ],
         },
         {
             id: "2",
             name: "Meningitis Polysaccharide",
+            displayName: "Meningitis Polysaccharide",
             code: "RVC_MENPOLY",
             doses: [],
             dataElements: [
@@ -272,11 +284,12 @@ const metadataConfig: MetadataConfig = {
                 { id: "7", code: "RVC_AEB", optional: false, order: 1 },
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
-            ageGroups: [[["2 - 4 y"]], [["5 - 14 y"]], [["15 - 29 y"]]],
+            ageGroups: [[[co("2 - 4 y")]], [[co("5 - 14 y")]], [[co("15 - 29 y")]]],
         },
         {
             id: "3",
             name: "Meningitis Conjugate",
+            displayName: "Meningitis Conjugate",
             code: "RVC_MENCONJ",
             doses: [],
             dataElements: [
@@ -289,11 +302,16 @@ const metadataConfig: MetadataConfig = {
                 { id: "7", code: "RVC_AEB", optional: true, order: 1 },
                 { id: "8", code: "RVC_AEFI", optional: true, order: 1 },
             ],
-            ageGroups: [[["12 - 59 m"]], [["5 - 14 y"]], [["15 - 29 y", "15 - 19 y"]]],
+            ageGroups: [
+                [[co("12 - 59 m")]],
+                [[co("5 - 14 y")]],
+                [[co("15 - 29 y"), co("15 - 19 y")]],
+            ],
         },
         {
             id: "4",
             name: "Cholera",
+            displayName: "Cholera",
             code: "RVC_CHOLERA",
             doses: [],
             dataElements: [
@@ -301,11 +319,16 @@ const metadataConfig: MetadataConfig = {
                 { id: "2", code: "RVC_DOSES_USED", optional: false, order: 1 },
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
-            ageGroups: [[["12 - 59 m"]], [["5 - 14 y"]], [["15 - 99 y"], ["15 - 29 y", "> 30 y"]]],
+            ageGroups: [
+                [[co("12 - 59 m")]],
+                [[co("5 - 14 y")]],
+                [[co("15 - 99 y")], [co("15 - 29 y"), co("> 30 y")]],
+            ],
         },
         {
             id: "5",
             name: "PCV",
+            displayName: "PCV",
             code: "RVC_PCV",
             doses: [],
             dataElements: [
@@ -317,15 +340,16 @@ const metadataConfig: MetadataConfig = {
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
             ageGroups: [
-                [["6 w - 11 m"]],
-                [["12 - 23 m"]],
-                [["24 - 59 m"]],
-                [["5 - 14 y"], ["5 - 7 y", "8 - 14 y"]],
+                [[co("6 w - 11 m")]],
+                [[co("12 - 23 m")]],
+                [[co("24 - 59 m")]],
+                [[co("5 - 14 y")], [co("5 - 7 y"), co("8 - 14 y")]],
             ],
         },
         {
             id: "6",
             name: "Pertussis Penta",
+            displayName: "Pertussis Penta",
             code: "RVC_PERTPENTA",
             doses: [],
             dataElements: [
@@ -337,15 +361,16 @@ const metadataConfig: MetadataConfig = {
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
             ageGroups: [
-                [["6 w - 11 m"]],
-                [["12 - 23 m"]],
-                [["24 - 59 m"]],
-                [["5 - 14 y"], ["5 - 7 y", "8 - 14 y"]],
+                [[co("6 w - 11 m")]],
+                [[co("12 - 23 m")]],
+                [[co("24 - 59 m")]],
+                [[co("5 - 14 y")], [co("5 - 7 y"), co("8 - 14 y")]],
             ],
         },
         {
             id: "7",
             name: "Yellow Fever",
+            displayName: "Yellow Fever",
             code: "RVC_YELLOW_FEVER",
             doses: [],
             dataElements: [
@@ -360,19 +385,20 @@ const metadataConfig: MetadataConfig = {
             ],
             ageGroups: [
                 [
-                    ["9 - 59 m"],
-                    ["9 - 11 m", "12 - 23 m", "25 - 59 m"],
-                    ["12 - 59 m"],
-                    ["12 - 23 m", "25 - 59 m"],
+                    [co("9 - 59 m")],
+                    [co("9 - 11 m"), co("12 - 23 m"), co("25 - 59 m")],
+                    [co("12 - 59 m")],
+                    [co("12 - 23 m"), co("25 - 59 m")],
                 ],
-                [["12 - 23 m"]],
-                [["5 - 14 y"]],
-                [["15 - 99 y"], ["15 - 29 y", ">30 y"]],
+                [[co("12 - 23 m")]],
+                [[co("5 - 14 y")]],
+                [[co("15 - 99 y")], [co("15 - 29 y"), co(">30 y")]],
             ],
         },
         {
             id: "8",
             name: "Japanese Encephalitis",
+            displayName: "Japanese Encephalitis",
             code: "RVC_JPENC",
             doses: [],
             dataElements: [
@@ -386,15 +412,16 @@ const metadataConfig: MetadataConfig = {
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
             ageGroups: [
-                [["8 - 11 m"], ["9 - 11 m"], ["6 - 11 m"]],
-                [["12 - 59 m"]],
-                [["5 - 14 y"]],
-                [["15 - 29 y"]],
+                [[co("8 - 11 m")], [co("9 - 11 m")], [co("6 - 11 m")]],
+                [[co("12 - 59 m")]],
+                [[co("5 - 14 y")]],
+                [[co("15 - 29 y")]],
             ],
         },
         {
             id: "9",
             name: "Dengue",
+            displayName: "Dengue",
             code: "RVC_DENGUE",
             doses: [],
             dataElements: [
@@ -407,11 +434,12 @@ const metadataConfig: MetadataConfig = {
                 { id: "7", code: "RVC_AEB", optional: false, order: 1 },
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
-            ageGroups: [[["9 - 14 y"]], [["15 - 29 y"]]],
+            ageGroups: [[[co("9 - 14 y")]], [[co("15 - 29 y")]]],
         },
         {
             id: "10",
             name: "Typhoid Fever",
+            displayName: "Typhoid Fever",
             code: "RVC_TYPHOID_FEVER",
             doses: [],
             dataElements: [
@@ -425,10 +453,10 @@ const metadataConfig: MetadataConfig = {
                 { id: "8", code: "RVC_AEFI", optional: false, order: 1 },
             ],
             ageGroups: [
-                [["6 - 11 m"]],
-                [["12 - 59 m"]],
-                [["5 - 14 y"]],
-                [["15 - 45 y"], ["15 - 29 y", "30 - 45 y"]],
+                [[co("6 - 11 m")]],
+                [[co("12 - 59 m")]],
+                [[co("5 - 14 y")]],
+                [[co("15 - 45 y")], [co("15 - 29 y"), co("30 - 45 y")]],
             ],
         },
     ],

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -22,6 +22,7 @@ export type TargetPopulationData = TargetPopulationData_;
 
 export interface Antigen {
     id: string;
+    displayName: string;
     name: string;
     code: string;
     doses: { id: string; name: string }[];

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -4,7 +4,11 @@ import moment from "moment";
 
 import { PaginatedObjects, OrganisationUnitPathOnly, Response } from "./db.types";
 import DbD2, { ApiResponse, toStatusResponse } from "./db-d2";
-import { AntigensDisaggregation, SectionForDisaggregation } from "./AntigensDisaggregation";
+import {
+    AntigensDisaggregation,
+    CampaignType,
+    SectionForDisaggregation,
+} from "./AntigensDisaggregation";
 import { MetadataConfig, getDashboardCode, getByIndex } from "./config";
 import { AntigenDisaggregationEnabled } from "./AntigensDisaggregation";
 import {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -33,7 +33,6 @@ export const baseConfig = {
     categoryCodeForAntigens: "RVC_ANTIGEN",
     categoryCodeForAgeGroup: "RVC_AGE_GROUP",
     categoryCodeForDoses: "RVC_DOSE",
-    categoryCodeForType: "RVC_TYPE",
     categoryComboCodeForAgeGroup: "RVC_AGE_GROUP",
     categoryComboCodeForAntigenAgeGroup: "RVC_ANTIGEN_AGE_GROUP",
     categoryComboCodeForAntigenDosesAgeGroup: "RVC_ANTIGEN_DOSE_AGE_GROUP",

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -33,6 +33,7 @@ export const baseConfig = {
     categoryCodeForAntigens: "RVC_ANTIGEN",
     categoryCodeForAgeGroup: "RVC_AGE_GROUP",
     categoryCodeForDoses: "RVC_DOSE",
+    categoryCodeForType: "RVC_TYPE",
     categoryComboCodeForAgeGroup: "RVC_AGE_GROUP",
     categoryComboCodeForAntigenAgeGroup: "RVC_ANTIGEN_AGE_GROUP",
     categoryComboCodeForAntigenDosesAgeGroup: "RVC_ANTIGEN_DOSE_AGE_GROUP",
@@ -40,6 +41,9 @@ export const baseConfig = {
     dataElementGroupCodeForPopulation: "RVC_POPULATION",
     categoryComboCodeForTeams: "RVC_TEAM",
     categoryCodeForTeams: "RVC_TEAM",
+    categoryOptionCodeReactive: "RVC_REACTIVE",
+    categoryOptionCodePreventive: "RVC_PREVENTIVE",
+    categoryOptionGroupOfAntigensWithSelectableType: "RVC_ANTIGEN_TYPE_SELECTABLE",
     legendSetsCode: "RVC_LEGEND_ZERO",
     attributeCodeForApp: "RVC_CREATED_BY_VACCINATION_APP",
     attributeNameForHideInTallySheet: "hideInTallySheet",
@@ -107,6 +111,7 @@ export interface MetadataConfig extends BaseConfig {
         dataElements: { id: string; code: string; optional: boolean; order: number }[];
         ageGroups: Array<CategoryOption[][]>;
         doses: Array<{ id: string; code: string; name: string; displayName: string }>;
+        isTypeSelectable: boolean;
     }>;
     legendSets: Array<{
         id: string;
@@ -254,6 +259,12 @@ function getAntigens(
     const dataElementGroupsByCode = _.keyBy(dataElementGroups, "code");
     const categoryOptionGroupsByCode = _.keyBy(categoryOptionGroups, "code");
 
+    const antigenIdsSelectable = new Set(
+        _(categoryOptionGroupsByCode)
+            .getOrFail(baseConfig.categoryOptionGroupOfAntigensWithSelectableType)
+            .categoryOptions.map(co => co.id)
+    );
+
     const antigensMetadata = categoryOptions.map(
         (categoryOption): MetadataConfig["antigens"][0] => {
             const getDataElements = (typeString: string) => {
@@ -325,6 +336,7 @@ function getAntigens(
                 dataElements: dataElementSorted,
                 ageGroups: ageGroups,
                 doses: doses,
+                isTypeSelectable: antigenIdsSelectable.has(categoryOption.id),
             };
         }
     );

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -401,7 +401,14 @@ export default class DbD2 {
                 DataValueResponse
             >;
         });
-        const errorResponses = responses.filter(response => response.status !== "SUCCESS");
+
+        const errorResponses = responses.filter(response => {
+            if ("httpStatus" in response) {
+                return response.response.status !== "SUCCESS";
+            } else {
+                return response.status !== "SUCCESS";
+            }
+        });
 
         if (_(errorResponses).isEmpty()) {
             return { status: true };

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -398,3 +398,11 @@ export interface DashboardMetadataRequest {
     categoryOptions: CategoryOptionsCustom[];
     organisationUnits: OrganisationUnitWithName[];
 }
+
+export function getId<T extends { id: string }>(obj: T): string {
+    return obj.id;
+}
+
+export function getCode<T extends { code: string }>(obj: T): string {
+    return obj.code;
+}

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -180,6 +180,7 @@ export interface Section {
 export interface DataSet extends Sharing {
     id: string;
     name: string;
+    shortName: string;
     description: string;
     periodType: string;
     categoryCombo: Ref;

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -316,10 +316,19 @@ export interface DataValueRequest {
     dataValues: DataValueToPost[];
 }
 
-export interface DataValueResponse {
+export type DataValueResponse = DataValuePreV40Response | DataValueNewPostV40Response;
+
+export interface DataValuePreV40Response {
     responseType: "ImportSummary";
     status: "SUCCESS" | "ERROR";
     description: string;
+}
+
+export interface DataValueNewPostV40Response {
+    status: "OK" | "ERROR";
+    httpStatus: "OK" | "ERROR";
+    httpStatusCode: number;
+    response: DataValuePreV40Response;
 }
 
 export type MetadataFields = { [key in ModelName]: ModelFields };

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,0 +1,6 @@
+declare module "@dhis2/d2-i18n" {
+    export function t(value: string, namespace?: object): string;
+    export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
+    export const store: { data: object };
+}

--- a/src/utils/age-groups.ts
+++ b/src/utils/age-groups.ts
@@ -1,15 +1,18 @@
 import _ from "lodash";
 import "./lodash-mixins";
-import { Category } from "../models/db.types";
+import { Category, CategoryOption } from "../models/db.types";
 
 interface SortConfig {
     categoryComboCodeForAgeGroup: string;
     categories: Category[];
 }
 
-export function sortAgeGroups(config: SortConfig, names: string[]): string[] {
+export function sortAgeGroups(
+    config: SortConfig,
+    categoryOptions: CategoryOption[]
+): CategoryOption[] {
     const ageGroupCategory = _(config.categories)
-        .keyBy("code")
+        .keyBy(category => category.code)
         .getOrFail(config.categoryComboCodeForAgeGroup);
 
     const indexByName: _.Dictionary<number> = _(ageGroupCategory.categoryOptions)
@@ -17,5 +20,8 @@ export function sortAgeGroups(config: SortConfig, names: string[]): string[] {
         .fromPairs()
         .value();
 
-    return _.sortBy(names, name => indexByName[name] || 0);
+    return _.sortBy(
+        categoryOptions,
+        categoryOption => indexByName[categoryOption.displayName] || 0
+    );
 }

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -6,5 +6,9 @@ export function goToDhis2Url(d2, path) {
 
 export function getDhis2Url(d2, path) {
     const baseUrl = d2.system.systemInfo.contextPath;
-    return [baseUrl.replace(/\/$/, ""), path.replace(/^\//, "")].join("/");
+    const isDev = process.env.NODE_ENV === "development";
+    const pathWithoutLeadingSlash = path.replace(/^\//, "");
+    return isDev
+        ? `/dhis2/` + pathWithoutLeadingSlash
+        : [baseUrl.replace(/\/$/, ""), pathWithoutLeadingSlash].join("/");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,7 +3213,7 @@ concat-stream@1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^1.5.0:
+concat-stream@^1.4.7, concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -5828,6 +5828,13 @@ html-webpack-plugin@4.0.0-alpha.2:
     pretty-error "^2.0.2"
     tapable "^1.0.0"
     util.promisify "1.0.0"
+
+html@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/html/-/html-1.0.0.tgz#a544fa9ea5492bfb3a2cca8210a10be7b5af1f61"
+  integrity sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==
+  dependencies:
+    concat-stream "^1.4.7"
 
 htmlparser2@^3.9.1:
   version "3.10.0"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #?

### :memo: Implementation

- [ ] Metadata: category type (options: preventive, reactive)
- [ ] Metadata: category option group to list all the antigens (category options) which are type-selectable
- [ ] Metadata: add category "campaign type" to categoryCombos "Required" which are rendered in an antigen tab
- [ ] UI step "Configure indicators": Show radio if the antigen is type-selectable.
- [ ] Custom form: use reactive (default) or preventive cocId, but do not render the corresponding header.

### Metadata

### :art: Screenshots