### PR TITLE
[release] Refactor&Fixes

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-05-28T08:31:26.574Z\n"
-"PO-Revision-Date: 2024-05-28T08:31:26.574Z\n"
+"POT-Creation-Date: 2024-07-03T09:01:39.856Z\n"
+"PO-Revision-Date: 2024-07-03T09:01:39.856Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -332,6 +332,9 @@ msgid "Antigens"
 msgstr ""
 
 msgid "Cancel"
+msgstr ""
+
+msgid "Return to Listing"
 msgstr ""
 
 msgid "Population distribution (%)"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-05-28T08:31:26.574Z\n"
+"POT-Creation-Date: 2024-07-03T09:01:39.856Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -403,6 +403,9 @@ msgstr "Antígenos"
 
 msgid "Cancel"
 msgstr "Cancelar"
+
+msgid "Return to Listing"
+msgstr "Volver al listado"
 
 msgid "Population distribution (%)"
 msgstr "Distribución por edad (%)"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-05-28T08:31:26.574Z\n"
+"POT-Creation-Date: 2024-07-03T09:01:39.856Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -409,6 +409,9 @@ msgstr "Antigènes"
 
 msgid "Cancel"
 msgstr "Annuler"
+
+msgid "Return to Listing"
+msgstr "Retour à la liste"
 
 msgid "Population distribution (%)"
 msgstr "Répartition démographique (%)"

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -17,7 +17,6 @@ import DisaggregationStep from "../steps/disaggregation/DisaggregationStep";
 import { memoize } from "../../utils/memoize";
 import ExitWizardButton from "../wizard/ExitWizardButton";
 import { getVisitedAndUpdate } from "../utils/page-visited";
-import { redirectToLandingPageIfLegacy } from "../campaign-configuration/validations";
 
 class CampaignWizard extends React.Component {
     static propTypes = {
@@ -48,8 +47,6 @@ class CampaignWizard extends React.Component {
                 ? await Campaign.get(config, db, match.params.id)
                 : Campaign.create(config, db);
 
-            if (redirectToLandingPageIfLegacy(campaign, snackbar, history)) return;
-
             const campaignHasDataValues = await campaign.hasDataValues().catch(err => {
                 console.error(err);
                 // Could not get data values (i.e. the user has no access to the org units),
@@ -68,7 +65,7 @@ class CampaignWizard extends React.Component {
         return !!this.props.match.params.id;
     }
 
-    getStepsBaseInfo() {
+    getStepsBaseInfo(campaign) {
         return [
             {
                 key: "general-info",
@@ -89,7 +86,10 @@ class CampaignWizard extends React.Component {
                 key: "organisation-units",
                 label: i18n.t("Organisation Units"),
                 component: OrganisationUnitsStep,
-                validationKeys: ["organisationUnits", "teams"],
+                validationKeys: _.compact([
+                    campaign && !campaign.isLegacy() ? "organisationUnits" : null,
+                    "teams",
+                ]),
                 description: i18n.t(
                     `Select the health facilities or vaccination areas which will implement the campaign. At least one must be selected.`
                 ),
@@ -173,7 +173,7 @@ class CampaignWizard extends React.Component {
         const { campaign, dialogOpen, pagesVisited, campaignHasDataValues } = this.state;
         window.campaign = campaign;
 
-        const steps = this.getStepsBaseInfo().map(step => ({
+        const steps = this.getStepsBaseInfo(campaign).map(step => ({
             ...step,
             warning: campaignHasDataValues
                 ? i18n.t(

--- a/src/components/campaign-wizard/CampaignWizard.jsx
+++ b/src/components/campaign-wizard/CampaignWizard.jsx
@@ -40,7 +40,7 @@ class CampaignWizard extends React.Component {
     }
 
     async componentDidMount() {
-        const { db, config, match, snackbar, history } = this.props;
+        const { db, config, match } = this.props;
 
         try {
             const campaign = this.isEdit()

--- a/src/components/data-entry/DataEntry.jsx
+++ b/src/components/data-entry/DataEntry.jsx
@@ -6,7 +6,10 @@ import ReactDOM from "react-dom";
 import moment from "moment";
 
 import PageHeader from "../shared/PageHeader";
-import { getOrganisationUnitsById, getPeriodDatesFromDataSetId } from "../../models/datasets";
+import {
+    getOrganisationUnitsByDataSetId,
+    getPeriodDatesFromDataSetId,
+} from "../../models/datasets";
 import { getDhis2Url } from "../../utils/routes";
 import { LinearProgress } from "@material-ui/core";
 import { withPageVisited } from "../utils/page-visited-app";
@@ -32,7 +35,9 @@ class DataEntry extends React.Component {
             match: { params },
         } = this.props;
         const dataSetId = params.id;
-        const organisationUnits = dataSetId ? await getOrganisationUnitsById(dataSetId, d2) : null;
+        const organisationUnits = dataSetId
+            ? await getOrganisationUnitsByDataSetId(dataSetId, d2)
+            : null;
 
         if (!dataSetId || (dataSetId && organisationUnits)) {
             this.setState({ isDataEntryIdValid: true }, () => {

--- a/src/components/steps/disaggregation/AntigenSection.tsx
+++ b/src/components/steps/disaggregation/AntigenSection.tsx
@@ -122,14 +122,14 @@ class TypeSelect extends React.Component<TypeSelectProps> {
                             onChange={this.handleOptionChange}
                         >
                             <FormControlLabel
-                                value="reactive"
-                                control={<Radio />}
-                                label={i18n.t("Reactive")}
-                            />
-                            <FormControlLabel
                                 value="preventive"
                                 control={<Radio />}
                                 label={i18n.t("Preventive")}
+                            />
+                            <FormControlLabel
+                                value="reactive"
+                                control={<Radio />}
+                                label={i18n.t("Reactive")}
                             />
                         </RadioGroup>
                     </FormControl>

--- a/src/components/steps/save/SaveStep.jsx
+++ b/src/components/steps/save/SaveStep.jsx
@@ -155,12 +155,17 @@ class SaveStep extends React.Component {
         ].join("");
     }
 
+    returnToListing = () => {
+        this.props.history.push("/campaign-configuration");
+    };
+
     render() {
         const { classes, campaign } = this.props;
         const { orgUnits, errorMessage, isSaving, dialogOpen } = this.state;
 
         const LiEntry = this.renderLiEntry;
         const disaggregation = campaign.getEnabledAntigensDisaggregation();
+        const isLegacyCampaign = campaign.isLegacy();
 
         return (
             <React.Fragment>
@@ -212,12 +217,35 @@ class SaveStep extends React.Component {
                         </LiEntry>
                     </ul>
 
+                    {isLegacyCampaign && (
+                        <div style={{ marginBottom: 20, color: "#FAA" }}>
+                            {i18n.t(
+                                "This campaign is not editable, please contact the administrator."
+                            )}
+                        </div>
+                    )}
+
                     <Button onClick={this.cancel} variant="contained">
                         {i18n.t("Cancel")}
                     </Button>
-                    <Button className={classes.saveButton} onClick={this.save} variant="contained">
-                        {i18n.t("Save")}
-                    </Button>
+
+                    {!isLegacyCampaign ? (
+                        <Button
+                            className={classes.saveButton}
+                            onClick={this.save}
+                            variant="contained"
+                        >
+                            {i18n.t("Save")}
+                        </Button>
+                    ) : (
+                        <Button
+                            className={classes.saveButton}
+                            onClick={this.returnToListing}
+                            variant="contained"
+                        >
+                            {i18n.t("Return to Listing")}
+                        </Button>
+                    )}
 
                     {isSaving && <LinearProgress />}
 

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -56,7 +56,7 @@ export class AntigenDisaggregation extends Struct<AntigenDisaggregationData>() {
             .find(value => value.selected);
 
         const selectedCode = selected ? selected.option.code : undefined;
-        return selectedCode === baseConfig.categoryOptionCodePreventive ? "preventive" : "reactive";
+        return selectedCode === baseConfig.categoryOptionCodeReactive ? "reactive" : "preventive";
     }
 
     updateCampaignType(type: CampaignType): AntigenDisaggregation {
@@ -395,7 +395,7 @@ export class AntigensDisaggregation {
         });
 
         return !disaggregation.isTypeSelectable
-            ? disaggregation.updateCampaignType("reactive")
+            ? disaggregation.updateCampaignType("preventive")
             : disaggregation;
     }
 

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -1,4 +1,4 @@
-import { CategoryOption, DataElement, getCode, Maybe, Ref } from "./db.types";
+import { Category, CategoryOption, DataElement, getCode, Maybe, Ref } from "./db.types";
 import _ from "lodash";
 import { MetadataConfig, getRvcCode, baseConfig } from "./config";
 import { Antigen } from "./campaign";
@@ -265,31 +265,12 @@ export class AntigensDisaggregation {
 
             const wasCategorySelected = !_(categoryOptionsEnabled).isEmpty();
 
-            const options = groups.map(optionGroup => {
-                const index = wasCategorySelected
-                    ? _(optionGroup).findIndex(
-                          options =>
-                              !_(options)
-                                  .intersectionBy(categoryOptionsEnabled, co => co.id)
-                                  .isEmpty()
-                      )
-                    : 0;
-                const indexSelected = index >= 0 ? index : 0;
-
-                return {
-                    indexSelected,
-                    values: optionGroup.map((options, optionGroupIndex) => {
-                        const isOptionGroupSelected =
-                            wasCategorySelected && indexSelected === optionGroupIndex;
-                        return options.map(option => ({
-                            option: option,
-                            selected: isOptionGroupSelected
-                                ? _(categoryOptionsEnabled).some(co => co.id === option.id)
-                                : true,
-                        }));
-                    }),
-                };
-            });
+            const options = getCategoryOptions(
+                antigenConfig,
+                category,
+                groups,
+                categoryOptionsEnabled
+            );
 
             const selected = wasCategorySelected ? true : !optional;
 
@@ -451,6 +432,59 @@ export class AntigensDisaggregation {
 
         return { getByOptions: getCocIdByCategoryOptions };
     }
+}
+
+function getCategoryOptions(
+    antigenConfig: MetadataConfig["antigens"][0],
+    category: Category,
+    groups: CategoryOption[][][],
+    categoryOptionsEnabled: Ref[]
+) {
+    const categoryOverride = antigenConfig.categoriesOverride[category.code];
+    const wasCategorySelected = !_(categoryOptionsEnabled).isEmpty();
+
+    return groups.map(optionGroup => {
+        const index = wasCategorySelected
+            ? _(optionGroup).findIndex(
+                  options =>
+                      !_(options)
+                          .intersectionBy(categoryOptionsEnabled, co => co.id)
+                          .isEmpty()
+              )
+            : 0;
+
+        const indexSelected = index >= 0 ? index : 0;
+
+        const values = _(optionGroup)
+            .map((options, optionGroupIndex) => {
+                const isOptionGroupSelected =
+                    wasCategorySelected && indexSelected === optionGroupIndex;
+
+                const optionsFiltered = _(options)
+                    .map(option => {
+                        const optionIsNotInOverride =
+                            categoryOverride &&
+                            !_(categoryOverride.options).some(co => co.id === option.id);
+
+                        if (optionIsNotInOverride) return null;
+
+                        return {
+                            option: option,
+                            selected: isOptionGroupSelected
+                                ? _(categoryOptionsEnabled).some(co => co.id === option.id)
+                                : true,
+                        };
+                    })
+                    .compact()
+                    .value();
+
+                return optionsFiltered.length == 0 ? null : optionsFiltered;
+            })
+            .compact()
+            .value();
+
+        return { indexSelected: indexSelected, values: values };
+    });
 }
 
 export function getDataElements(

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -478,7 +478,7 @@ function getCategoryOptions(
                     .compact()
                     .value();
 
-                return optionsFiltered.length == 0 ? null : optionsFiltered;
+                return optionsFiltered.length === 0 ? null : optionsFiltered;
             })
             .compact()
             .value();

--- a/src/models/CampaignDb.ts
+++ b/src/models/CampaignDb.ts
@@ -6,7 +6,14 @@ import "../utils/lodash-mixins";
 
 import Campaign from "./campaign";
 import { DataSetCustomForm } from "./DataSetCustomForm";
-import { Maybe, MetadataResponse, DataEntryForm, Section, CategoryOption } from "./db.types";
+import {
+    Maybe,
+    MetadataResponse,
+    DataEntryForm,
+    Section,
+    CategoryOption,
+    NamedRef,
+} from "./db.types";
 import { Metadata, DataSet, Response } from "./db.types";
 import { formatDay } from "../utils/date";
 import { getDataElements, CocMetadata } from "./AntigensDisaggregation";
@@ -39,7 +46,7 @@ interface PostSaveMetadata {
     dataSets: DataSet[];
     dataEntryForms: DataEntryForm[];
     sections: Section[];
-    categoryOptions: object[];
+    categoryOptions: NamedRef[];
 }
 
 export default class CampaignDb {
@@ -261,7 +268,7 @@ export default class CampaignDb {
             }
         }
         // Update Team Category with new categoryOptions (teams)
-        Teams.updateTeamCategory(db, allMetadata.categoryOptions, teamsToDelete, config);
+        await Teams.updateTeamCategory(db, allMetadata.categoryOptions, teamsToDelete, config);
 
         if (!result.status) {
             return { status: false, error: result.error };

--- a/src/models/DataSetCustomForm.ts
+++ b/src/models/DataSetCustomForm.ts
@@ -564,6 +564,7 @@ export class DataSetCustomForm {
             translations: this.translations,
             dataElements: _.fromPairs(this.config.dataElements.map(de => [de.id, de.code])),
             dataInput: getDataInputFromCampaign(this.campaign),
+            attributeCodeForDataInputPeriods: this.config.attributeCodeForDataInputPeriods,
         };
         const toJSON = (obj: any) => JSON.stringify(obj, null, 2);
         // Remove the empty export (it's required by the linter, but does not work on a browser)
@@ -675,4 +676,5 @@ interface CustomFormOptions {
     translations: object;
     dataElements: Record<Id, Code>;
     dataInput: Maybe<DataInput>;
+    attributeCodeForDataInputPeriods: string;
 }

--- a/src/models/DataSetCustomForm.ts
+++ b/src/models/DataSetCustomForm.ts
@@ -392,13 +392,13 @@ export class DataSetCustomForm {
 
     getGeneralDataElements(disaggregations: Disaggregations): DataElement[] {
         const hasAntigensDisaggregation = (dataElement: DataElement) =>
-            !_(dataElement.categories)
+            _(dataElement.categories)
                 .map(getCode)
                 .includes(this.config.dataElementGroupCodeForAntigens);
 
         return _(disaggregations)
-            .flatMap("dataElements")
-            .filter(hasAntigensDisaggregation)
+            .flatMap(disaggregation => disaggregation.dataElements)
+            .reject(hasAntigensDisaggregation)
             .uniqBy(getId)
             .value();
     }

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -53,7 +53,7 @@ export const baseConfig = {
     dataElementCodeForAgeDistribution: "RVC_AGE_DISTRIBUTION",
     dataElementCodeForPopulationByAge: "RVC_POPULATION_BY_AGE",
     dataSetDashboardCodePrefix: "RVC_CAMPAIGN",
-    dataSetExtraCodes: ["DS_NSd_3"],
+    dataSetExtraCodes: ["DS_VPMVCd"],
     userRoleNames: {
         manager: [userRoles.campaignManager],
         feedback: [userRoles.feedback],

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -53,7 +53,7 @@ export const baseConfig = {
     dataElementCodeForAgeDistribution: "RVC_AGE_DISTRIBUTION",
     dataElementCodeForPopulationByAge: "RVC_POPULATION_BY_AGE",
     dataSetDashboardCodePrefix: "RVC_CAMPAIGN",
-    dataSetExtraCodes: ["DS_VPMVCd"],
+    dataSetExtraIdentifiables: ["DS_NSd_3", "SrPi5dzhNcD"],
     userRoleNames: {
         manager: [userRoles.campaignManager],
         feedback: [userRoles.feedback],
@@ -447,7 +447,7 @@ export async function getMetadataConfig(db: DbD2): Promise<MetadataConfig> {
         indicators: { fields: { id: true, code: true }, filters: [codeFilter] },
         dataSets: {
             fields: { id: true, name: true, code: true },
-            filters: [`code:in:[${baseConfig.dataSetExtraCodes.join(",")}]`],
+            filters: [`identifiable:in:[${baseConfig.dataSetExtraIdentifiables.join(",")}]`],
         },
         legendSets: { fields: { id: true, code: true }, filters: [codeFilter] },
         organisationUnitLevels: {},
@@ -491,11 +491,7 @@ export async function getMetadataConfig(db: DbD2): Promise<MetadataConfig> {
         userRoles: metadata.userRoles,
         legendSets: metadata.legendSets,
         indicators: metadata.indicators,
-        dataSets: {
-            extraActivities: metadata.dataSets.filter(dataSet =>
-                _(baseConfig.dataSetExtraCodes).includes(dataSet.code)
-            ),
-        },
+        dataSets: { extraActivities: metadata.dataSets },
     };
 
     return metadataConfig;

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -37,7 +37,7 @@ export const baseConfig = {
     categoryComboCodeForAgeGroup: "RVC_AGE_GROUP",
     categoryComboCodeForAntigenAgeGroup: "RVC_ANTIGEN_AGE_GROUP",
     categoryComboCodeForAntigenDosesAgeGroup: "RVC_ANTIGEN_DOSE_AGE_GROUP",
-    categoryComboCodeForAntigenDosesAgeGroupType: "RVC_ANTIGEN_DOSE_AGE_GROUP_TYPE",
+    categoryComboCodeForAntigenDosesAgeGroupType: "RVC_ANTIGEN_DOSE_TYPE_AGE_GROUP",
     dataElementGroupCodeForAntigens: "RVC_ANTIGEN",
     dataElementGroupCodeForPopulation: "RVC_POPULATION",
     categoryComboCodeForTeams: "RVC_TEAM",

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -302,7 +302,7 @@ function getAntigens(
                 getDataElements("OPTIONAL")
             );
 
-            const dataElementSorted = _.orderBy(dataElementsForAntigens, "order");
+            const dataElementSorted = _.orderBy(dataElementsForAntigens, de => de.order);
 
             const mainAgeGroups = _(categoryOptionGroupsByCode).getOrFail(
                 getRvcCode([categoryOption.code, "AGE_GROUP"])
@@ -315,7 +315,7 @@ function getAntigens(
                 const codePrefix = getRvcCode([
                     categoryOption.code,
                     "AGE_GROUP",
-                    mainAgeGroup.displayName,
+                    mainAgeGroup.name,
                 ]);
                 const disaggregatedAgeGroups = _(categoryOptionGroups)
                     .filter(cog => cog.code.startsWith(codePrefix))
@@ -420,7 +420,7 @@ function getPopulationMetadata(
 
 function getAttributes(attributes: Attribute[]) {
     const attributesByCode = _(attributes).keyBy(attribute => attribute.code);
-    const attributesByName = _(attributes).keyBy(attribute => attribute.displayName);
+    const attributesByName = _(attributes).keyBy(attribute => attribute.name);
 
     return {
         app: attributesByCode.getOrFail(baseConfig.attributeCodeForApp),
@@ -432,7 +432,7 @@ function getAttributes(attributes: Attribute[]) {
 function getDefaults(metadata: RawMetadataConfig): MetadataConfig["defaults"] {
     return {
         categoryOptionCombo: _(metadata.categoryOptionCombos)
-            .keyBy("displayName")
+            .keyBy(coc => coc.displayName)
             .getOrFail("default"),
     };
 }

--- a/src/models/dashboard-items.js
+++ b/src/models/dashboard-items.js
@@ -56,11 +56,11 @@ export const dashboardItemsConfig = {
         DATA_ELEMENT: ["RVC_AEB", "RVC_AEFI", "RVC_DOSES_ADMINISTERED", "RVC_DOSES_USED"],
     },
     chartsByAntigen: {
-        coverageBySite: {
+        coverageByCampaign: {
             ...definitions.coverageByDosesAndPeriod,
-            area: "site",
-            title: ns => i18n.t("Coverage by Site {{- period}} (do not edit this chart)", ns),
-            appendCode: "Coverage by site",
+            area: "campaign",
+            title: ns => i18n.t("Coverage by Campaign {{- period}} (do not edit this chart)", ns),
+            appendCode: "Coverage by campaign",
         },
         coverageByArea: {
             ...definitions.coverageByDosesAndPeriod,
@@ -68,11 +68,11 @@ export const dashboardItemsConfig = {
             title: ns => i18n.t("Coverage by Area {{- period}} (do not edit this chart)", ns),
             appendCode: "Coverage by area",
         },
-        coverageByCampaign: {
+        coverageBySite: {
             ...definitions.coverageByDosesAndPeriod,
-            area: "campaign",
-            title: ns => i18n.t("Coverage by Campaign {{- period}} (do not edit this chart)", ns),
-            appendCode: "Coverage by campaign",
+            area: "site",
+            title: ns => i18n.t("Coverage by Site {{- period}} (do not edit this chart)", ns),
+            appendCode: "Coverage by site",
         },
     },
     globalTables: {

--- a/src/models/datasets.js
+++ b/src/models/datasets.js
@@ -87,7 +87,7 @@ function isDataSetInUserOrgUnits(d2, dataSet) {
     );
 }
 
-export async function getOrganisationUnitsById(id, d2) {
+export async function getOrganisationUnitsByDataSetId(id, d2) {
     const fields = "organisationUnits[id,name]";
     const dataSet = await d2.models.dataSets.get(id, { fields }).catch(() => undefined);
     const organisationUnits = dataSet ? dataSet.organisationUnits.toArray() : null;

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -116,7 +116,7 @@ export const metadataFields: MetadataFields = {
         id: true,
         code: true,
         valueType: true,
-        displayName: true,
+        name: true,
     },
     categories: {
         id: true,
@@ -458,16 +458,6 @@ export default class DbD2 {
                   status: false,
                   error: errors.join("\n"),
               };
-    }
-
-    public async getAttributeIdByCode(code: string): Promise<Attribute | undefined> {
-        const { attributes } = await this.api.get("/attributes", {
-            paging: true,
-            pageSize: 1,
-            filter: [`code:eq:${code}`],
-            fields: ["id"],
-        });
-        return attributes[0];
     }
 
     public getAnalytics(request: AnalyticsRequest): Promise<AnalyticsResponse> {

--- a/src/models/db-d2.ts
+++ b/src/models/db-d2.ts
@@ -12,7 +12,6 @@ import {
     MetadataGetParams,
     ModelName,
     MetadataFields,
-    Attribute,
     DataEntryForm,
     DataValueResponse,
     Response,

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -151,6 +151,10 @@ export interface Ref {
     id: string;
 }
 
+export interface NamedRef extends Ref {
+    name: string;
+}
+
 export interface Metadata {
     dataSets?: Array<DataSet>;
     dataEntryForms?: Array<DataEntryForm>;
@@ -401,6 +405,10 @@ export interface DashboardMetadataRequest {
 
 export function getId<T extends { id: string }>(obj: T): string {
     return obj.id;
+}
+
+export function getRef<T extends { id: string }>(obj: T): Ref {
+    return { id: obj.id };
 }
 
 export function getCode<T extends { code: string }>(obj: T): string {

--- a/src/models/db.types.ts
+++ b/src/models/db.types.ts
@@ -119,7 +119,7 @@ export interface Attribute {
     id: string;
     code: string;
     valueType: "TEXT" | "BOOLEAN";
-    displayName: string;
+    name: string;
 }
 
 export interface AttributeValue {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8694p8xhu, https://app.clickup.com/t/8694jjb57 (DEV)

### :memo: Implementation

- [x] Post new cocs on campaign update instead of calling categoryOptionComboUpdate
- [x] Add dataset "Vaccination Preventive mass campaign - Daily":DS_VPMVCd:HDB7J5A2vm0
- [x] Remove isLegacy check on edit and move to save step
- [x] Add support for selectable categoryOptions for antigen/category (this will allow Tetanus -> woman only, pregant/childbearing only)
- [x] https://app.clickup.com/t/8694p8xhu?comment=90120049330102&threadedComment=90120055636863:
  - [x] Metadata: [tetanus-type-for-sections-dataelements.json](https://github.com/user-attachments/files/16410852/tetanus-type-for-sections-dataelements.json)


### Deploy

- Tetanus metadata (age groups):  [tetanus-metadata.json](https://github.com/user-attachments/files/16052800/tetanus-metadata.json)


- To generate COCs: Data Administration -> Maintenance -> Update category option combinations.

### Questions

- [x] Tomás: "I notice that it takes more time to show the org unit tree than before, is it normal?" In my tests (msfe-bikengevacc-mfp) the render is pretty quick. instance URL/username to check?
- [x] Tomás: "Another thing I noticed. I enter data for "Vaccine doses used", it works well, but when I apply the filter "Reactive / Preventive", it is not working. Seems that is not saving in a COC that includes the filter. All the DE of the Antigens should be linked to this filter "Reactive / Preventive"". Only "doses administered" are disaggregated by preventive/reactive. 