### PR TITLE
[feature] old campaigns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vaccination-app",
     "description": "DHIS2 MSF Reactive Vaccination App",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",
@@ -101,7 +101,7 @@
         "wait-on": "^3.2.0"
     },
     "manifest.webapp": {
-        "name": "Reactive Vaccination",
+        "name": "Reactive Vaccination (Deprecated)",
         "description": "DHIS2 MSF Reactive Vaccination App",
         "icons": {
             "48": "icon.png"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8694jjb57

Client needs to extend the endDate of a campaign. App >= 2.1.0 has a breaking change, orgUnit with campaign data was moved, so we must create a branch from 2.0.0

### :memo: Implementation

- [ ] Change manifest->name: Reactive Vaccination (Deprecated)
- [ ] Version 2.0.1 (we will use 2.0.x for this old campaign requirements)
- [ ] Check that both versions can coexist (yes, they have different paths)