### PR TITLE
[feature] Force selection of campaign type for antigens

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-11-05T08:11:47.684Z\n"
-"PO-Revision-Date: 2024-11-05T08:11:47.684Z\n"
+"POT-Creation-Date: 2025-04-01T08:49:03.846Z\n"
+"PO-Revision-Date: 2025-04-01T08:49:03.846Z\n"
 
 msgid "Campaigns"
 msgstr ""
@@ -472,6 +472,9 @@ msgid "Select at least one antigen"
 msgstr ""
 
 msgid "You must select at least one category option"
+msgstr ""
+
+msgid "You must select the type for antigen {{antigen}}"
 msgstr ""
 
 msgid "No target population defined"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-11-05T08:11:47.684Z\n"
+"POT-Creation-Date: 2025-04-01T08:49:03.846Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -562,6 +562,9 @@ msgstr "Seleccione al menos un antígeno"
 
 msgid "You must select at least one category option"
 msgstr "Debe seleccionar al menos una categoría"
+
+msgid "You must select the type for antigen {{antigen}}"
+msgstr "Debe seleccionar el tipo de campaña para el antígeno {{antigen}}"
 
 msgid "No target population defined"
 msgstr "Población objetivo no definida"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-11-05T08:11:47.684Z\n"
+"POT-Creation-Date: 2025-04-01T08:49:03.846Z\n"
 "PO-Revision-Date: 2018-11-15T11:18:10.896Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -576,6 +576,9 @@ msgstr "Sélectionnez au moins un antigène"
 
 msgid "You must select at least one category option"
 msgstr "Vous devez sélectionner au moins une catégorie"
+
+msgid "You must select the type for antigen {{antigen}}"
+msgstr "Vous devez sélectionner le type pour l'antigène {{antigen}}"
 
 msgid "No target population defined"
 msgstr "Aucune population cible définie"

--- a/src/components/steps/disaggregation/AntigenSection.tsx
+++ b/src/components/steps/disaggregation/AntigenSection.tsx
@@ -20,7 +20,7 @@ import SimpleCheckbox from "../../forms/SimpleCheckBox";
 import DataElement from "./DataElement";
 import { memoize } from "../../../utils/memoize";
 
-type Path = (number | string)[];
+type Path = Array<number | string>;
 
 interface AntigenSectionProps extends WithStyles<typeof styles> {
     antigen: AntigenDisaggregation;

--- a/src/models/AntigensDisaggregation.ts
+++ b/src/models/AntigensDisaggregation.ts
@@ -122,7 +122,7 @@ export type AntigenDisaggregationCategoriesData =
 export type AntigenDisaggregationOptionGroup = AntigenDisaggregationCategoriesData[0]["options"][0];
 
 export type AntigenDisaggregationEnabled = Array<{
-    type: CampaignType;
+    type: Maybe<CampaignType>;
     antigen: Antigen;
     ageGroups: Array<CategoryOption>;
     dataElements: Array<{
@@ -210,7 +210,9 @@ export class AntigensDisaggregation {
     }
 
     public validate(): Array<{ key: string; namespace: _.Dictionary<string> }> {
-        const errors = _(this.getEnabled())
+        const enabled = this.getEnabled();
+
+        const errors1 = _(enabled)
             .flatMap(antigen => antigen.dataElements)
             .flatMap(dataElement => dataElement.categories)
             .map(category =>
@@ -221,7 +223,20 @@ export class AntigensDisaggregation {
             .compact()
             .value();
 
-        return errors;
+        const errors2 = _(enabled)
+            .filter(antigen => !antigen.type)
+            .map(antigen =>
+                antigen.type
+                    ? null
+                    : {
+                          key: "antigen_has_no_selected_type",
+                          namespace: { antigen: antigen.antigen.displayName },
+                      }
+            )
+            .compact()
+            .value();
+
+        return _.concat(errors1, errors2);
     }
 
     static getCategories(
@@ -343,7 +358,7 @@ export class AntigensDisaggregation {
 
                 return {
                     ageGroups: ageGroups,
-                    type: antigenDisaggregation.type || defaultCampaignType,
+                    type: antigenDisaggregation.type,
                     antigen: {
                         code: antigenDisaggregation.code,
                         name: antigenDisaggregation.name,
@@ -403,7 +418,7 @@ export class AntigensDisaggregation {
             isTypeSelectable: antigenConfig.isTypeSelectable,
         });
 
-        if (!disaggregation.isTypeSelectable || !disaggregation.type) {
+        if (!disaggregation.isTypeSelectable && !disaggregation.type) {
             return disaggregation.updateCampaignType(defaultCampaignType);
         } else {
             return disaggregation;
@@ -419,6 +434,7 @@ export class AntigensDisaggregation {
             .value();
 
         // Add age groups required by target population data values
+
         const allCategoryComboCodes = [
             ...categoryComboCodes,
             this.config.categoryCodeForAgeGroup,

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -15,6 +15,8 @@ const translations = {
 
     select_at_least_one_option_for_category: () =>
         i18n.t("You must select at least one category option"),
+    antigen_has_no_selected_type: namespace =>
+        i18n.t("You must select the type for antigen {{antigen}}", namespace),
 
     no_target_population_defined: () => i18n.t("No target population defined"),
     total_population_invalid: namespace =>


### PR DESCRIPTION
### :pushpin: References

* **Issue:** https://app.clickup.com/t/8698dwhyc

### :memo: Implementation

- [x] On a new antigen, the radio selector preventive/reactive should appear as unselected
- [x] Validate that the type is selected for that step